### PR TITLE
Minor setup.py bug

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -82,7 +82,7 @@ setup(
     install_requires=[
         "numpy>=1.20.3",
         "gym>=0.17.3",
-        "pyyaml>-5.3.1",
+        "pyyaml>=5.3.1",
         "imageio>=2.9.0"
     ],
     cmdclass={


### PR DESCRIPTION
Bug: pyyaml dependency string was not valid, updated from ">-5.3.1" to ">=5.3.1". 

Was causing issues on exporting a conda environment I was using