### PR TITLE
Tutorial fixes.

### DIFF
--- a/docs/about/introduction.rst
+++ b/docs/about/introduction.rst
@@ -4,7 +4,7 @@
 Introduction
 ############
 
-One of the most important things about AI research is data. In many Game Environments the rate of data (rendered frames per second, or state representations per second) is relatively slow meaning very long training times. Researchers can compensate for this problem by parallelizing the number of games being played, sometimes on expensive hardware and sometimes on several servers requiring network infrastructure to pass states to the actual learning algorithms. For many researchers and hobbyists who want to learn. This approach is unobtainable and only the research teams with lots of funding and engineers supporting the hardware and infrastructure required.
+One of the most important things about AI research is data. In many Game Environments the rate of data (rendered frames per second, or state representations per second) is relatively slow meaning very long training times. Researchers can compensate for this problem by parallelizing the number of games being played, sometimes on expensive hardware and sometimes on several servers requiring network infrastructure to pass states to the actual learning algorithms. For many researchers and hobbyists who want to learn AI, this approach is unobtainable and accessible only for the research teams with lots of funding and engineers supporting the hardware and infrastructure required.
 
 Griddly provides a solution to this issue. 
 

--- a/docs/getting-started/gdy/index.rst
+++ b/docs/getting-started/gdy/index.rst
@@ -19,12 +19,13 @@ A GDY file looks like this:
     Version: "0.1"
     Environment:
       Name: sokoban
-      TileSize: 24
-      BackgroundTile: images/gvgai/newset/floor2.png
+      Observers:
+        Sprite2D:
+          TileSize: 24
+          BackgroundTile: gvgai/newset/floor2.png
       Player:
-        Mode: SINGLE # This is only a single player game
-        Actions:
-          AvatarObject: avatar # The player can only control a single avatar in the game
+        Count: 1 # This is only a single player game
+        AvatarObject: avatar # The player can only control a single avatar in the game
       Termination:
         Win:
           - eq: [box:count, 0] # If there are no boxes left
@@ -92,44 +93,45 @@ A GDY file looks like this:
       MapCharacter: b
       Observers:
         Sprite2D:
-          Image: images/gvgai/newset/block1.png
+          - Image: gvgai/newset/block1.png
 
     - Name: wall
       MapCharacter: w
       Observers:
-      Sprite2D:
-        TilingMode: WALL_16
-        Image:
-          - images/gvgai/oryx/wall3_0.png
-          - images/gvgai/oryx/wall3_1.png
-          - images/gvgai/oryx/wall3_2.png
-          - images/gvgai/oryx/wall3_3.png
-          - images/gvgai/oryx/wall3_4.png
-          - images/gvgai/oryx/wall3_5.png
-          - images/gvgai/oryx/wall3_6.png
-          - images/gvgai/oryx/wall3_7.png
-          - images/gvgai/oryx/wall3_8.png
-          - images/gvgai/oryx/wall3_9.png
-          - images/gvgai/oryx/wall3_10.png
-          - images/gvgai/oryx/wall3_11.png
-          - images/gvgai/oryx/wall3_12.png
-          - images/gvgai/oryx/wall3_13.png
-          - images/gvgai/oryx/wall3_14.png
-          - images/gvgai/oryx/wall3_15.png
+        Sprite2D:
+          - TilingMode: 
+              WALL_16
+            Image:
+              - gvgai/oryx/wall3_0.png
+              - gvgai/oryx/wall3_1.png
+              - gvgai/oryx/wall3_2.png
+              - gvgai/oryx/wall3_3.png
+              - gvgai/oryx/wall3_4.png
+              - gvgai/oryx/wall3_5.png
+              - gvgai/oryx/wall3_6.png
+              - gvgai/oryx/wall3_7.png
+              - gvgai/oryx/wall3_8.png
+              - gvgai/oryx/wall3_9.png
+              - gvgai/oryx/wall3_10.png
+              - gvgai/oryx/wall3_11.png
+              - gvgai/oryx/wall3_12.png
+              - gvgai/oryx/wall3_13.png
+              - gvgai/oryx/wall3_14.png
+              - gvgai/oryx/wall3_15.png
 
     - Name: hole
       Z: 1
       MapCharacter: h
       Observers:
         Sprite2D:
-          Image: images/gvgai/oryx/cspell4.png
+        - Image: gvgai/oryx/cspell4.png
 
     - Name: avatar
       Z: 2
       MapCharacter: A
       Observers:
         Sprite2D:
-          Image: images/gvgai/oryx/knight1.png
+        - Image: gvgai/oryx/knight1.png
 
 This is all thats needed to define a game of Sokoban that has two levels which look like this:
 

--- a/docs/tutorials/GDY/index.rst
+++ b/docs/tutorials/GDY/index.rst
@@ -22,11 +22,11 @@ The top level of GDY files always look like this:
    Objects: ...
 
 
-:ref:`Enviroment <doc_tutorials_gdy_environment>` - Define all the objects that might exist and how they will be rendered on screen.
+:ref:`Enviroment <doc_tutorials_gdy_environment>` -  Define how the player (or players) interact with the environment and design the levels.
 
 :ref:`Actions <doc_tutorials_gdy_actions>` - Define the mechanics of the environment. This is how the different objects interact with one another.
 
-:ref:`Objects <doc_tutorials_gdy_objects>` -  Define how the player (or players) interact with the environment and design the levels.
+:ref:`Objects <doc_tutorials_gdy_objects>` - Define all the objects that might exist and how they will be rendered on screen.
 
 Afterwards the environment can be loaded by Griddy and used in other projects. In this tutorial the environment will be loaded into an OpenAI gym wrapper and can be played with using your keyboard.
 


### PR DESCRIPTION
- Make the Intorduction paragraph of the docs make grammatically more sense.
- Fix GDY introduction page to work and render a Sokoban board.
- On the GDY tutorial page, the Environment and Objects descriptions were flipped.

Please note that I was just introduced to Griddly, so the changes should be reviewed carefully. I tried to fix some of the things I ran into when familiarizing myself with it.