### PR TITLE
Adding initial orientation to maps

### DIFF
--- a/src/Griddly/Core/LevelGenerators/MapGenerator.cpp
+++ b/src/Griddly/Core/LevelGenerators/MapGenerator.cpp
@@ -56,7 +56,7 @@ void MapGenerator::reset(std::shared_ptr<Grid> grid) {
 
       spdlog::debug("Adding object {0} to environment at location ({1},{2})", objectName, location[0], location[1]);
       auto object = objectGenerator_->newInstance(objectName, playerId, grid);
-      grid->addObject(location, object);
+      grid->addObject(location, object, true, nullptr, DiscreteOrientation(objectData.initialDirection));
     }
   }
 }
@@ -81,14 +81,16 @@ void MapGenerator::parseFromStream(std::istream& stream) {
 
   char currentPlayerId[3];
   int playerIdIdx = 0;
+  Direction currentDirection = Direction::NONE;
 
   char prevChar;
 
   while (auto ch = stream.get()) {
     switch (ch) {
       case EOF:
-        if (state == MapReaderState::READ_PLAYERID) {
-          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+        if (state == MapReaderState::READ_PLAYERID || state == MapReaderState::READ_INITIAL_ORIENTATION) {
+          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
+          currentDirection = Direction::NONE;
           state = MapReaderState::READ_NORMAL;
         }
         width_ = firstColCount;
@@ -103,8 +105,9 @@ void MapGenerator::parseFromStream(std::istream& stream) {
 
       case '\n':
         if (state == MapReaderState::READ_PLAYERID) {
-          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
           state = MapReaderState::READ_NORMAL;
+          currentDirection = Direction::NONE;
           colCount++;
         }
 
@@ -122,17 +125,19 @@ void MapGenerator::parseFromStream(std::istream& stream) {
       // Do nothing on whitespace
       case ' ':
       case '\t':
-        if (state == MapReaderState::READ_PLAYERID) {
-          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+        if (state == MapReaderState::READ_PLAYERID || state == MapReaderState::READ_INITIAL_ORIENTATION) {
+          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
           state = MapReaderState::READ_NORMAL;
+          currentDirection = Direction::NONE;
           colCount++;
         }
         break;
 
       case '.':  // dots just signify an empty space
-        if (state == MapReaderState::READ_PLAYERID) {
-          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+        if (state == MapReaderState::READ_PLAYERID || state == MapReaderState::READ_INITIAL_ORIENTATION) {
+          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
           state = MapReaderState::READ_NORMAL;
+          currentDirection = Direction::NONE;
           colCount++;
         }
         colCount++;
@@ -140,9 +145,24 @@ void MapGenerator::parseFromStream(std::istream& stream) {
         break;
 
       case '/':
-        if (state == MapReaderState::READ_PLAYERID) {
-          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+        if (state == MapReaderState::READ_PLAYERID || state == MapReaderState::READ_INITIAL_ORIENTATION) {
+          addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
           state = MapReaderState::READ_NORMAL;
+          currentDirection = Direction::NONE;
+        }
+        prevChar = ch;
+        break;
+
+      case '[':
+        if (state == MapReaderState::READ_PLAYERID) {
+          state = MapReaderState::READ_INITIAL_ORIENTATION;
+        }
+        prevChar = ch;
+        break;
+
+      case ']':
+        if (state != MapReaderState::READ_INITIAL_ORIENTATION) {
+          throw std::invalid_argument(fmt::format("Invalid closing bracket ']' for initial orientation in map row={0}", rowCount));
         }
         prevChar = ch;
         break;
@@ -160,11 +180,31 @@ void MapGenerator::parseFromStream(std::istream& stream) {
               currentPlayerId[playerIdIdx] = ch;
               playerIdIdx++;
             } else {
-              addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount);
+              addObject(currentObjectName, currentPlayerId, playerIdIdx, colCount, rowCount, currentDirection);
               currentObjectName = objectGenerator_->getObjectNameFromMapChar(ch);
               playerIdIdx = 0;
+              currentDirection = Direction::NONE;
               memset(currentPlayerId, 0x00, 3);
               colCount++;
+            }
+          } break;
+          case MapReaderState::READ_INITIAL_ORIENTATION: {
+            switch (ch) {
+              case 'U':
+                currentDirection = Direction::UP;
+                break;
+              case 'D':
+                currentDirection = Direction::DOWN;
+                break;
+              case 'L':
+                currentDirection = Direction::LEFT;
+                break;
+              case 'R':
+                currentDirection = Direction::RIGHT;
+                break;
+              default:
+                throw std::invalid_argument(fmt::format("Unknown direction character {0} at in map row={1}", ch, rowCount));
+                break;
             }
           } break;
         }
@@ -175,11 +215,12 @@ void MapGenerator::parseFromStream(std::istream& stream) {
   }
 }
 
-void MapGenerator::addObject(std::string objectName, char* playerIdString, int playerIdStringLength, uint32_t x, uint32_t y) {
+void MapGenerator::addObject(std::string& objectName, char* playerIdString, int playerIdStringLength, uint32_t x, uint32_t y, Direction direction) {
   auto playerId = playerIdStringLength > 0 ? atoi(playerIdString) : 0;
   GridInitInfo gridInitInfo;
   gridInitInfo.objectName = objectName;
   gridInitInfo.playerId = playerId;
+  gridInitInfo.initialDirection = direction;
   spdlog::debug("Adding object={0} with playerId={1} to location [{2}, {3}]", objectName, playerId, x, y);
 
   auto location = glm::ivec2(x, y);

--- a/src/Griddly/Core/LevelGenerators/MapGenerator.hpp
+++ b/src/Griddly/Core/LevelGenerators/MapGenerator.hpp
@@ -13,11 +13,13 @@ struct GridInitInfo {
   std::string objectName;
   int32_t playerId;
   int32_t zIdx;
+  Direction initialDirection;
 };
 
 enum class MapReaderState {
   READ_NORMAL,
-  READ_PLAYERID
+  READ_PLAYERID,
+  READ_INITIAL_ORIENTATION,
 };
 
 class MapGenerator : public LevelGenerator {
@@ -39,6 +41,6 @@ class MapGenerator : public LevelGenerator {
 
   const std::shared_ptr<ObjectGenerator> objectGenerator_;
 
-  void addObject(std::string objectName, char* playerIdString, int playerIdStringLength, uint32_t x, uint32_t y);
+  void addObject(std::string& objectName, char* playerIdString, int playerIdStringLength, uint32_t x, uint32_t y, Direction direction);
 };
 }  // namespace griddly

--- a/tests/src/Griddly/Core/LevelGenerator/MapReaderTest.cpp
+++ b/tests/src/Griddly/Core/LevelGenerator/MapReaderTest.cpp
@@ -390,4 +390,74 @@ TEST(MapGeneratorTest, testLoadStringMultipleOccupants) {
   EXPECT_TRUE(Mock::VerifyAndClearExpectations(mockObjectGeneratorPtr.get()));
 }
 
+TEST(MapGeneratorTest, testLoadStringInitialOrientation) {
+  auto mockObjectGeneratorPtr = std::shared_ptr<MockObjectGenerator>(new MockObjectGenerator());
+  auto mockGridPtr = std::shared_ptr<MockGrid>(new MockGrid());
+  auto mockWallObject = std::shared_ptr<MockObject>(new MockObject());
+  auto mockAvatarObject = std::shared_ptr<MockObject>(new MockObject());
+  auto mockDefaultObject = std::shared_ptr<MockObject>(new MockObject());
+
+  std::shared_ptr<MapGenerator> mapReader(new MapGenerator(1, mockObjectGeneratorPtr));
+
+  std::string wallObjectName = "wall";
+  std::string avatarObjectName = "avatar";
+
+  auto objectDefinitions = mockObjectDefinitions({wallObjectName, avatarObjectName});
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, getObjectDefinitions())
+      .WillRepeatedly(Return(objectDefinitions));
+
+  EXPECT_CALL(*mockGridPtr, initObject(Eq(wallObjectName), Eq(std::vector<std::string>{})))
+      .Times(1);
+
+  EXPECT_CALL(*mockGridPtr, initObject(Eq(avatarObjectName), Eq(std::vector<std::string>{})))
+      .Times(1);
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables)
+      .WillRepeatedly(ReturnRef(globalVariables));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, getObjectNameFromMapChar(Eq('W')))
+      .Times(12)
+      .WillRepeatedly(ReturnRef(wallObjectName));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, getObjectNameFromMapChar(Eq('P')))
+      .Times(1)
+      .WillRepeatedly(ReturnRef(avatarObjectName));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, newInstance(Eq("_empty"), Eq(0), Eq(mockGridPtr)))
+      .Times(1)
+      .WillRepeatedly(Return(mockDefaultObject));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, newInstance(Eq("_empty"), Eq(1), Eq(mockGridPtr)))
+      .Times(1)
+      .WillRepeatedly(Return(mockDefaultObject));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, newInstance(Eq(wallObjectName), Eq(0), Eq(mockGridPtr)))
+      .Times(12)
+      .WillRepeatedly(Return(mockWallObject));
+
+  EXPECT_CALL(*mockObjectGeneratorPtr, newInstance(Eq(avatarObjectName), Eq(1), Eq(mockGridPtr)))
+      .Times(1)
+      .WillRepeatedly(Return(mockAvatarObject));
+
+  EXPECT_CALL(*mockGridPtr, resetMap(Eq(5), Eq(3)))
+      .Times(1);
+
+  EXPECT_CALL(*mockGridPtr, addObject(_, Eq(mockWallObject), Eq(true), Eq(nullptr), Eq(DiscreteOrientation())))
+      .Times(12);
+
+  EXPECT_CALL(*mockGridPtr, addObject(_, Eq(mockAvatarObject), Eq(true), Eq(nullptr), Eq(DiscreteOrientation(Direction::DOWN))))
+      .Times(1);
+
+  std::string levelString = "W  W  W  W  W\nW  .  P1[D] .  W\n  W  W  W  W  W";
+  auto levelStringStream = std::stringstream(levelString);
+
+  mapReader->parseFromStream(levelStringStream);
+  mapReader->reset(mockGridPtr);
+
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(mockGridPtr.get()));
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(mockObjectGeneratorPtr.get()));
+}
+
 }  // namespace griddly


### PR DESCRIPTION
Fix for #154

Objects can now have their initial orientation set using [U], [D], [L], [R] after the map character:

`a[U]` (an object with map character `a` and initial direction UP 
