### PR TITLE
Improve branching terminations

### DIFF
--- a/python/tests/gdy/test_termination_steps.yaml
+++ b/python/tests/gdy/test_termination_steps.yaml
@@ -7,7 +7,7 @@ Environment:
     Lose:
       - Conditions:
           - eq: [ _steps, 100 ]
-        OpposingReward: -1
+        Reward: -1
   Levels:
     - |
       .  .  .

--- a/src/Griddly/Core/GDY/ConditionResolver.hpp
+++ b/src/Griddly/Core/GDY/ConditionResolver.hpp
@@ -37,7 +37,7 @@ class ConditionResolver {
     }
   }
 
-  ConditionFunction processConditions(YAML::Node &conditionNodeList, bool isTopLevel, LogicOp op) const {
+  ConditionFunction processConditions(YAML::Node &conditionNodeList, bool isTopLevel = false, LogicOp op = LogicOp::NONE) const {
     // We should have a single item and not a list
     if (!conditionNodeList.IsDefined()) {
       auto line = conditionNodeList.Mark().line;

--- a/src/Griddly/Core/GDY/ConditionResolver.hpp
+++ b/src/Griddly/Core/GDY/ConditionResolver.hpp
@@ -1,0 +1,92 @@
+#pragma once
+#include <yaml-cpp/yaml.h>
+
+#include <functional>
+#include <vector>
+
+namespace griddly {
+
+enum class LogicOp {
+  NONE,
+  AND,
+  OR,
+};
+
+template <class ConditionFunction>
+class ConditionResolver {
+ public:
+  ConditionFunction instantiateCondition(std::string &commandName, YAML::Node &conditionNode) const {
+    if (commandName == "eq") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a == b; }, conditionNode);
+    } else if (commandName == "gt") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a > b; }, conditionNode);
+    } else if (commandName == "gte") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a >= b; }, conditionNode);
+    } else if (commandName == "lt") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a < b; }, conditionNode);
+    } else if (commandName == "lte") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a <= b; }, conditionNode);
+    } else if (commandName == "neq") {
+      return resolveConditionArguments([](int32_t a, int32_t b) { return a != b; }, conditionNode);
+    } else if (commandName == "and") {
+      return processConditions(conditionNode, false, LogicOp::AND);
+    } else if (commandName == "or") {
+      return processConditions(conditionNode, false, LogicOp::OR);
+    } else {
+      throw std::invalid_argument(fmt::format("Unknown or badly defined condition command {0}.", commandName));
+    }
+  }
+
+  ConditionFunction processConditions(YAML::Node &conditionNodeList, bool isTopLevel, LogicOp op) const {
+    // We should have a single item and not a list
+    if (!conditionNodeList.IsDefined()) {
+      auto line = conditionNodeList.Mark().line;
+      auto errorString = fmt::format("Parse error line {0}. If statement is missing Conditions", line);
+      spdlog::error(errorString);
+      throw std::invalid_argument(errorString);
+    }
+
+    if (conditionNodeList.IsMap()) {
+      if (conditionNodeList.size() != 1) {
+        auto line = conditionNodeList.Mark().line;
+        auto errorString = fmt::format("Parse error line {0}. Conditions must contain a single top-level condition", line);
+        spdlog::error(errorString);
+        throw std::invalid_argument(errorString);
+      }
+      auto conditionNode = conditionNodeList.begin();
+      auto commandName = conditionNode->first.as<std::string>();
+      return instantiateCondition(commandName, conditionNode->second);
+
+    } else if (conditionNodeList.IsSequence()) {
+      std::vector<ConditionFunction> conditionList;
+      for (auto &&subConditionNode : conditionNodeList) {
+        auto validatedNode = validateCommandPairNode(subConditionNode);
+        auto commandName = validatedNode->first.as<std::string>();
+        conditionList.push_back(instantiateCondition(commandName, validatedNode->second));
+      }
+      switch (op) {
+        case LogicOp::AND:
+          return resolveAND(conditionList);
+        case LogicOp::OR:
+          return resolveOR(conditionList);
+        default: {
+          auto line = conditionNodeList.Mark().line;
+          auto errorString = fmt::format("Parse error line {0}. A sequence of conditions must be within an AND or an OR operator.", line);
+          spdlog::error(errorString);
+          throw std::invalid_argument(errorString);
+        }
+      }
+    } else {
+      auto line = conditionNodeList.Mark().line;
+      auto errorString = fmt::format("Conditions must be a map or a list", line);
+      spdlog::error(errorString);
+      throw std::invalid_argument(errorString);
+    }
+  }
+
+  virtual ConditionFunction resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node &conditionArgumentsNode) const = 0;
+  virtual ConditionFunction resolveAND(const std::vector<ConditionFunction> &conditionList) const = 0;
+  virtual ConditionFunction resolveOR(const std::vector<ConditionFunction> &conditionList) const = 0;
+};
+
+}  // namespace griddly

--- a/src/Griddly/Core/GDY/GDYFactory.cpp
+++ b/src/Griddly/Core/GDY/GDYFactory.cpp
@@ -562,7 +562,7 @@ void GDYFactory::parseTerminationConditions(YAML::Node terminationNode) {
 }
 
 void GDYFactory::setMaxSteps(uint32_t maxSteps) {
-  auto maxStepsGDY = fmt::format("ge: [_steps, {0}]", std::to_string(maxSteps));
+  auto maxStepsGDY = fmt::format("gte: [_steps, {0}]", std::to_string(maxSteps));
   auto maxStepsNode = YAML::Load(maxStepsGDY);
   terminationGenerator_->defineTerminationCondition(TerminationState::LOSE, 0, 0, maxStepsNode);
 }

--- a/src/Griddly/Core/GDY/GDYFactory.cpp
+++ b/src/Griddly/Core/GDY/GDYFactory.cpp
@@ -562,7 +562,7 @@ void GDYFactory::parseTerminationConditions(YAML::Node terminationNode) {
 }
 
 void GDYFactory::setMaxSteps(uint32_t maxSteps) {
-  auto maxStepsGDY = fmt::format("gte: [_steps, {0}]", std::to_string(maxSteps));
+  auto maxStepsGDY = fmt::format("gt: [_steps, {0}]", std::to_string(maxSteps));
   auto maxStepsNode = YAML::Load(maxStepsGDY);
   terminationGenerator_->defineTerminationCondition(TerminationState::LOSE, 0, 0, maxStepsNode);
 }

--- a/src/Griddly/Core/GDY/GDYFactory.cpp
+++ b/src/Griddly/Core/GDY/GDYFactory.cpp
@@ -509,13 +509,7 @@ void GDYFactory::parsePlayerDefinition(YAML::Node playerNode) {
 }
 
 void GDYFactory::parseTerminationConditionV1(TerminationState state, YAML::Node conditionNode) {
-  for (auto&& c : conditionNode) {
-    auto commandIt = validateCommandPairNode(c);
-    auto commandName = commandIt->first.as<std::string>();
-    auto commandArguments = singleOrListNodeToList(commandIt->second);
-
-    terminationGenerator_->defineTerminationCondition(state, commandName, 0, 0, commandArguments);
-  }
+  terminationGenerator_->defineTerminationCondition(state, 0, 0, conditionNode);
 }
 
 bool GDYFactory::parseTerminationConditionV2(TerminationState state, YAML::Node conditionListNode) {
@@ -531,13 +525,7 @@ bool GDYFactory::parseTerminationConditionV2(TerminationState state, YAML::Node 
     auto reward = rewardNode.as<int32_t>(0);
     auto opposingReward = opposingRewardNode.as<int32_t>(0);
 
-    for (auto&& i : conditionNode) {
-      auto commandIt = validateCommandPairNode(i);
-      auto commandName = commandIt->first.as<std::string>();
-      auto commandArguments = singleOrListNodeToList(commandIt->second);
-
-      terminationGenerator_->defineTerminationCondition(state, commandName, reward, opposingReward, commandArguments);
-    }
+    terminationGenerator_->defineTerminationCondition(state, reward, opposingReward, conditionNode);
   }
 
   return true;
@@ -574,7 +562,9 @@ void GDYFactory::parseTerminationConditions(YAML::Node terminationNode) {
 }
 
 void GDYFactory::setMaxSteps(uint32_t maxSteps) {
-  terminationGenerator_->defineTerminationCondition(TerminationState::LOSE, "gt", 0, 0, {"_steps", std::to_string(maxSteps)});
+  auto maxStepsGDY = fmt::format("ge: [_steps, {0}]", std::to_string(maxSteps));
+  auto maxStepsNode = YAML::Load(maxStepsGDY);
+  terminationGenerator_->defineTerminationCondition(TerminationState::LOSE, 0, 0, maxStepsNode);
 }
 
 void GDYFactory::parseGlobalVariables(YAML::Node variablesNode) {
@@ -762,7 +752,7 @@ ActionBehaviourDefinition GDYFactory::makeBehaviourDefinition(ActionBehaviourTyp
                                                               std::string associatedObjectName,
                                                               std::string actionName,
                                                               std::string commandName,
-                                                              BehaviourCommandArguments commandArguments,
+                                                              CommandArguments commandArguments,
                                                               YAML::Node actionPreconditionsNode,
                                                               CommandList conditionalCommands) {
   ActionBehaviourDefinition behaviourDefinition;
@@ -824,7 +814,7 @@ void GDYFactory::parseCommandNode(
     if (commandName == "exec" || commandName == "if") {
       // We have an execute action that we need to parse slightly differently
 
-      BehaviourCommandArguments commandArgumentMap;
+      CommandArguments commandArgumentMap;
 
       for (YAML::const_iterator execArgNode = commandNode.begin(); execArgNode != commandNode.end(); ++execArgNode) {
         auto execArgName = execArgNode->first.as<std::string>();

--- a/src/Griddly/Core/GDY/GDYFactory.hpp
+++ b/src/Griddly/Core/GDY/GDYFactory.hpp
@@ -30,7 +30,7 @@ class GDYFactory {
                                                            std::string associatedObjectName,
                                                            std::string actionName,
                                                            std::string commandName,
-                                                           BehaviourCommandArguments commandArguments,
+                                                           CommandArguments commandArguments,
                                                            YAML::Node actionPreconditionsNode,
                                                            CommandList conditionalCommands);
 

--- a/src/Griddly/Core/GDY/Objects/Object.cpp
+++ b/src/Griddly/Core/GDY/Objects/Object.cpp
@@ -116,7 +116,7 @@ BehaviourResult Object::onActionDst(std::shared_ptr<Action> action) {
   return {false, rewardAccumulator};
 }
 
-std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> Object::resolveVariables(BehaviourCommandArguments &commandArguments, bool allowStrings) const {
+std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> Object::resolveVariables(CommandArguments &commandArguments, bool allowStrings) const {
   std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolvedVariables;
   for (auto commandArgument : commandArguments) {
     resolvedVariables[commandArgument.first] = std::make_shared<ObjectVariable>(ObjectVariable(commandArgument.second, availableVariables_, allowStrings));
@@ -181,7 +181,7 @@ BehaviourCondition Object::resolveOR(const std::vector<BehaviourCondition>& cond
 //   }
 // }
 
-BehaviourFunction Object::instantiateConditionalBehaviour(std::string &commandName, BehaviourCommandArguments &commandArguments, CommandList &subCommands) {
+BehaviourFunction Object::instantiateConditionalBehaviour(std::string &commandName, CommandArguments &commandArguments, CommandList &subCommands) {
   if (subCommands.size() == 0) {
     return instantiateBehaviour(commandName, commandArguments);
   }
@@ -306,7 +306,7 @@ BehaviourResult Object::executeBehaviourFunctionList(std::unordered_map<uint32_t
   return {false, rewardAccumulator};
 }
 
-BehaviourFunction Object::instantiateBehaviour(std::string &commandName, BehaviourCommandArguments &commandArguments) {
+BehaviourFunction Object::instantiateBehaviour(std::string &commandName, CommandArguments &commandArguments) {
   // Command just used in tests
   if (commandName == "nop") {
     return [this](std::shared_ptr<Action> action) -> BehaviourResult {
@@ -651,7 +651,7 @@ void Object::addActionSrcBehaviour(
     std::string actionName,
     std::string destinationObjectName,
     std::string commandName,
-    BehaviourCommandArguments commandArguments,
+    CommandArguments commandArguments,
     CommandList conditionalCommands) {
   spdlog::debug("Adding behaviour command={0} when action={1} is performed on object={2} by object={3}", commandName, actionName, destinationObjectName, getObjectName());
 
@@ -666,7 +666,7 @@ void Object::addActionDstBehaviour(
     std::string actionName,
     std::string sourceObjectName,
     std::string commandName,
-    BehaviourCommandArguments commandArguments,
+    CommandArguments commandArguments,
     CommandList conditionalCommands) {
   spdlog::debug("Adding behaviour command={0} when object={1} performs action={2} on object={3}", commandName, sourceObjectName, actionName, getObjectName());
 
@@ -840,7 +840,7 @@ std::vector<std::shared_ptr<Action>> Object::getInitialActions(std::shared_ptr<A
 }
 
 template <typename C>
-C Object::getCommandArgument(BehaviourCommandArguments &commandArguments, std::string commandArgumentKey, C defaultValue) {
+C Object::getCommandArgument(CommandArguments &commandArguments, std::string commandArgumentKey, C defaultValue) {
   auto commandArgumentIt = commandArguments.find(commandArgumentKey);
   if (commandArgumentIt == commandArguments.end()) {
     return defaultValue;
@@ -849,7 +849,7 @@ C Object::getCommandArgument(BehaviourCommandArguments &commandArguments, std::s
   return commandArgumentIt->second.as<C>(defaultValue);
 }
 
-std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> Object::resolveActionMetaData(BehaviourCommandArguments &commandArguments) {
+std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> Object::resolveActionMetaData(CommandArguments &commandArguments) {
   auto commandArgumentIt = commandArguments.find("MetaData");
   if (commandArgumentIt == commandArguments.end()) {
     return {};

--- a/src/Griddly/Core/GDY/Objects/Object.cpp
+++ b/src/Griddly/Core/GDY/Objects/Object.cpp
@@ -137,27 +137,49 @@ BehaviourCondition Object::resolveConditionArguments(const std::function<bool(in
   };
 }
 
-BehaviourCondition Object::instantiateCondition(std::string &commandName, YAML::Node &conditionNode) const {
-  if (commandName == "eq") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a == b; }, conditionNode);
-  } else if (commandName == "gt") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a > b; }, conditionNode);
-  } else if (commandName == "gte") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a >= b; }, conditionNode);
-  } else if (commandName == "lt") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a < b; }, conditionNode);
-  } else if (commandName == "lte") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a <= b; }, conditionNode);
-  } else if (commandName == "neq") {
-    return resolveConditionArguments([](int32_t a, int32_t b) { return a != b; }, conditionNode);
-  } else if (commandName == "and") {
-    return processConditions(conditionNode, false, LogicOp::AND);
-  } else if (commandName == "or") {
-    return processConditions(conditionNode, false, LogicOp::OR);
-  } else {
-    throw std::invalid_argument(fmt::format("Unknown or badly defined condition command {0}.", commandName));
-  }
+BehaviourCondition Object::resolveAND(const std::vector<BehaviourCondition>& conditionList) const {
+  return [conditionList](const std::shared_ptr<Action> &action) -> bool {
+    for (const auto &condition : conditionList) {
+      if (!condition(action)) {
+        return false;
+      }
+    }
+    return true;
+  };
 }
+
+BehaviourCondition Object::resolveOR(const std::vector<BehaviourCondition>& conditionList) const {
+  return [conditionList](const std::shared_ptr<Action> &action) -> bool {
+    for (const auto &condition : conditionList) {
+      if (condition(action)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+// BehaviourCondition Object::instantiateCondition(std::string &commandName, YAML::Node &conditionNode) const {
+//   if (commandName == "eq") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a == b; }, conditionNode);
+//   } else if (commandName == "gt") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a > b; }, conditionNode);
+//   } else if (commandName == "gte") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a >= b; }, conditionNode);
+//   } else if (commandName == "lt") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a < b; }, conditionNode);
+//   } else if (commandName == "lte") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a <= b; }, conditionNode);
+//   } else if (commandName == "neq") {
+//     return resolveConditionArguments([](int32_t a, int32_t b) { return a != b; }, conditionNode);
+//   } else if (commandName == "and") {
+//     return processConditions(conditionNode, false, LogicOp::AND);
+//   } else if (commandName == "or") {
+//     return processConditions(conditionNode, false, LogicOp::OR);
+//   } else {
+//     throw std::invalid_argument(fmt::format("Unknown or badly defined condition command {0}.", commandName));
+//   }
+// }
 
 BehaviourFunction Object::instantiateConditionalBehaviour(std::string &commandName, BehaviourCommandArguments &commandArguments, CommandList &subCommands) {
   if (subCommands.size() == 0) {
@@ -204,76 +226,64 @@ BehaviourFunction Object::instantiateConditionalBehaviour(std::string &commandNa
   };
 }
 
-/**
- * @brief Deliciously recursive function for processing trees of conditions
- * 
- * @param conditionNodeList 
- * @param isTopLevel 
- * @return BehaviourCondition 
- */
-BehaviourCondition Object::processConditions(YAML::Node &conditionNodeList, bool isTopLevel, LogicOp op) const {
-  // We should have a single item and not a list
-  if (!conditionNodeList.IsDefined()) {
-    auto line = conditionNodeList.Mark().line;
-    auto errorString = fmt::format("Parse error line {0}. If statement is missing Conditions", line);
-    spdlog::error(errorString);
-    throw std::invalid_argument(errorString);
-  }
+// BehaviourCondition Object::processConditions(YAML::Node &conditionNodeList, bool isTopLevel, LogicOp op) const {
+//   // We should have a single item and not a list
+//   if (!conditionNodeList.IsDefined()) {
+//     auto line = conditionNodeList.Mark().line;
+//     auto errorString = fmt::format("Parse error line {0}. If statement is missing Conditions", line);
+//     spdlog::error(errorString);
+//     throw std::invalid_argument(errorString);
+//   }
 
-  if (conditionNodeList.IsMap()) {
-    if (conditionNodeList.size() != 1) {
-      auto line = conditionNodeList.Mark().line;
-      auto errorString = fmt::format("Parse error line {0}. Conditions must contain a single top-level condition", line);
-      spdlog::error(errorString);
-      throw std::invalid_argument(errorString);
-    }
-    auto conditionNode = conditionNodeList.begin();
-    auto commandName = conditionNode->first.as<std::string>();
-    return instantiateCondition(commandName, conditionNode->second);
+//   if (conditionNodeList.IsMap()) {
+//     if (conditionNodeList.size() != 1) {
+//       auto line = conditionNodeList.Mark().line;
+//       auto errorString = fmt::format("Parse error line {0}. Conditions must contain a single top-level condition", line);
+//       spdlog::error(errorString);
+//       throw std::invalid_argument(errorString);
+//     }
+//     auto conditionNode = conditionNodeList.begin();
+//     auto commandName = conditionNode->first.as<std::string>();
+//     return instantiateCondition(commandName, conditionNode->second);
 
-  } else if (conditionNodeList.IsSequence()) {
-    std::vector<BehaviourCondition> conditionList;
-    for (auto &&subConditionNode : conditionNodeList) {
-      auto validatedNode = validateCommandPairNode(subConditionNode);
-      auto commandName = validatedNode->first.as<std::string>();
-      conditionList.push_back(instantiateCondition(commandName, validatedNode->second));
-    }
-    switch (op) {
-      case LogicOp::AND: {
-        return [conditionList](const std::shared_ptr<Action> &action) -> bool {
-          for (const auto &condition : conditionList) {
-            if (!condition(action)) {
-              return false;
-            }
-          }
-          return true;
-        };
-      } break;
-      case LogicOp::OR: {
-        return [conditionList](const std::shared_ptr<Action> &action) -> bool {
-          for (const auto &condition : conditionList) {
-            if (condition(action)) {
-              return true;
-            }
-          }
-          return false;
-        };
-      }
-      default: {
-        auto line = conditionNodeList.Mark().line;
-        auto errorString = fmt::format("Parse error line {0}. A sequence of conditions must be within an AND or an OR operator.", line);
-        spdlog::error(errorString);
-        throw std::invalid_argument(errorString);
-      }
-    }
-
-  } else {
-    auto line = conditionNodeList.Mark().line;
-    auto errorString = fmt::format("Conditions must be a map or a list", line);
-    spdlog::error(errorString);
-    throw std::invalid_argument(errorString);
-  }
-}
+//   } else if (conditionNodeList.IsSequence()) {
+//     std::vector<BehaviourCondition> conditionList;
+//     for (auto &&subConditionNode : conditionNodeList) {
+//       auto validatedNode = validateCommandPairNode(subConditionNode);
+//       auto commandName = validatedNode->first.as<std::string>();
+//       conditionList.push_back(instantiateCondition(commandName, validatedNode->second));
+//     }
+//     switch (op) {
+//       case LogicOp::AND: {
+//         return resolveAnd()
+//       };
+//     }
+//     break;
+//     case LogicOp::OR: {
+//       return [conditionList](const std::shared_ptr<Action> &action) -> bool {
+//         for (const auto &condition : conditionList) {
+//           if (condition(action)) {
+//             return true;
+//           }
+//         }
+//         return false;
+//       };
+//     }
+//     default: {
+//       auto line = conditionNodeList.Mark().line;
+//       auto errorString = fmt::format("Parse error line {0}. A sequence of conditions must be within an AND or an OR operator.", line);
+//       spdlog::error(errorString);
+//       throw std::invalid_argument(errorString);
+//     }
+//   }
+// }
+// else {
+//   auto line = conditionNodeList.Mark().line;
+//   auto errorString = fmt::format("Conditions must be a map or a list", line);
+//   spdlog::error(errorString);
+//   throw std::invalid_argument(errorString);
+// }
+// }  // namespace griddly
 
 /**
  * @brief executes a list of behaviour functions and accumulates the rewards

--- a/src/Griddly/Core/GDY/Objects/Object.hpp
+++ b/src/Griddly/Core/GDY/Objects/Object.hpp
@@ -15,7 +15,7 @@
 #include "../ConditionResolver.hpp"
 #include "ObjectVariable.hpp"
 
-#define CommandArguments std::unordered_map<std::string, YAML::Node>
+#define CommandArguments std::map<std::string, YAML::Node>
 #define BehaviourFunction std::function<BehaviourResult(const std::shared_ptr<Action>&)>
 #define BehaviourCondition std::function<bool(const std::shared_ptr<Action>&)>
 #define CommandList std::vector<std::pair<std::string, CommandArguments>>

--- a/src/Griddly/Core/GDY/Objects/Object.hpp
+++ b/src/Griddly/Core/GDY/Objects/Object.hpp
@@ -12,6 +12,7 @@
 
 #include "../Actions/Direction.hpp"
 #include "../YAMLUtils.hpp"
+#include "../ConditionResolver.hpp"
 #include "ObjectVariable.hpp"
 
 #define BehaviourCommandArguments std::unordered_map<std::string, YAML::Node>
@@ -70,13 +71,7 @@ struct PathFinderConfig {
   uint32_t maxSearchDepth = 100;
 };
 
-enum class LogicOp {
-  NONE,
-  AND,
-  OR,
-};
-
-class Object : public std::enable_shared_from_this<Object> {
+class Object : public std::enable_shared_from_this<Object>, ConditionResolver<BehaviourCondition> {
  public:
   virtual const glm::ivec2& getLocation() const;
 
@@ -189,8 +184,9 @@ class Object : public std::enable_shared_from_this<Object> {
 
   std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolveVariables(BehaviourCommandArguments& variables, bool allowStrings = false) const;
 
-  BehaviourCondition instantiateCondition(std::string& commandName, YAML::Node& conditionNode) const;
-  BehaviourCondition resolveConditionArguments(const std::function<bool(int32_t, int32_t)> condition, YAML::Node &conditionArgumentsNode) const;
+  BehaviourCondition resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node &conditionArgumentsNode) const override;
+  BehaviourCondition resolveAND(const std::vector<BehaviourCondition>& conditionList) const override;
+  BehaviourCondition resolveOR(const std::vector<BehaviourCondition>& conditionList) const override;
 
   BehaviourFunction instantiateBehaviour(std::string& commandName, BehaviourCommandArguments& commandArguments);
   BehaviourFunction instantiateConditionalBehaviour(std::string& commandName, BehaviourCommandArguments& commandArguments, CommandList& subCommands);

--- a/src/Griddly/Core/GDY/Objects/Object.hpp
+++ b/src/Griddly/Core/GDY/Objects/Object.hpp
@@ -15,10 +15,10 @@
 #include "../ConditionResolver.hpp"
 #include "ObjectVariable.hpp"
 
-#define BehaviourCommandArguments std::unordered_map<std::string, YAML::Node>
+#define CommandArguments std::unordered_map<std::string, YAML::Node>
 #define BehaviourFunction std::function<BehaviourResult(const std::shared_ptr<Action>&)>
 #define BehaviourCondition std::function<bool(const std::shared_ptr<Action>&)>
-#define CommandList std::vector<std::pair<std::string, BehaviourCommandArguments>>
+#define CommandList std::vector<std::pair<std::string, CommandArguments>>
 
 namespace griddly {
 
@@ -109,9 +109,9 @@ class Object : public std::enable_shared_from_this<Object>, ConditionResolver<Be
 
   virtual BehaviourResult onActionDst(std::shared_ptr<Action> action);
 
-  virtual void addActionSrcBehaviour(std::string action, std::string destinationObjectName, std::string commandName, BehaviourCommandArguments commandArguments, CommandList nestedCommands);
+  virtual void addActionSrcBehaviour(std::string action, std::string destinationObjectName, std::string commandName, CommandArguments commandArguments, CommandList nestedCommands);
 
-  virtual void addActionDstBehaviour(std::string action, std::string sourceObjectName, std::string commandName, BehaviourCommandArguments commandArguments, CommandList nestedCommands);
+  virtual void addActionDstBehaviour(std::string action, std::string sourceObjectName, std::string commandName, CommandArguments commandArguments, CommandList nestedCommands);
 
   virtual std::shared_ptr<int32_t> getVariableValue(std::string variableName);
 
@@ -124,7 +124,6 @@ class Object : public std::enable_shared_from_this<Object>, ConditionResolver<Be
   virtual void setInitialActionDefinitions(std::vector<InitialActionDefinition> actionDefinitions);
 
   // Conditional functions
-  BehaviourCondition processConditions(YAML::Node& conditionNodeList, bool isTopLevel = false, LogicOp op = LogicOp::NONE) const;
   BehaviourResult executeBehaviourFunctionList(std::unordered_map<uint32_t, int32_t>& rewardAccumulator, const std::vector<BehaviourFunction>& behaviourList, const std::shared_ptr<Action>& action) const;
 
   Object(std::string objectName, char mapCharacter, uint32_t playerId, uint32_t zIdx, std::unordered_map<std::string, std::shared_ptr<int32_t>> availableVariables, std::shared_ptr<ObjectGenerator> objectGenerator, std::weak_ptr<Grid> grid);
@@ -178,18 +177,18 @@ class Object : public std::enable_shared_from_this<Object>, ConditionResolver<Be
   PathFinderConfig configurePathFinder(YAML::Node& searchNode, std::string actionName);
 
   template <typename C>
-  static C getCommandArgument(BehaviourCommandArguments& commandArguments, std::string commandArgumentKey, C defaultValue);
+  static C getCommandArgument(CommandArguments& commandArguments, std::string commandArgumentKey, C defaultValue);
 
-  std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolveActionMetaData(BehaviourCommandArguments& commandArguments);
+  std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolveActionMetaData(CommandArguments& commandArguments);
 
-  std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolveVariables(BehaviourCommandArguments& variables, bool allowStrings = false) const;
+  std::unordered_map<std::string, std::shared_ptr<ObjectVariable>> resolveVariables(CommandArguments& variables, bool allowStrings = false) const;
 
   BehaviourCondition resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node &conditionArgumentsNode) const override;
   BehaviourCondition resolveAND(const std::vector<BehaviourCondition>& conditionList) const override;
   BehaviourCondition resolveOR(const std::vector<BehaviourCondition>& conditionList) const override;
 
-  BehaviourFunction instantiateBehaviour(std::string& commandName, BehaviourCommandArguments& commandArguments);
-  BehaviourFunction instantiateConditionalBehaviour(std::string& commandName, BehaviourCommandArguments& commandArguments, CommandList& subCommands);
+  BehaviourFunction instantiateBehaviour(std::string& commandName, CommandArguments& commandArguments);
+  BehaviourFunction instantiateConditionalBehaviour(std::string& commandName, CommandArguments& commandArguments, CommandList& subCommands);
 
   ActionExecutor getActionExecutorFromString(std::string executorString) const;
 };

--- a/src/Griddly/Core/GDY/Objects/ObjectGenerator.hpp
+++ b/src/Griddly/Core/GDY/Objects/ObjectGenerator.hpp
@@ -21,7 +21,7 @@ struct ActionBehaviourDefinition {
   std::string destinationObjectName;
   std::string actionName;
   std::string commandName;
-  BehaviourCommandArguments commandArguments;
+  CommandArguments commandArguments;
   YAML::Node actionPreconditionsNode = YAML::Node(YAML::NodeType::Undefined);
   CommandList conditionalCommands{};
   float executionProbability = 1.0;

--- a/src/Griddly/Core/GDY/TerminationGenerator.cpp
+++ b/src/Griddly/Core/GDY/TerminationGenerator.cpp
@@ -7,11 +7,9 @@
 
 namespace griddly {
 
-void TerminationGenerator::defineTerminationCondition(TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> commandArguments) {
-  spdlog::debug("Adding termination condition definition {0} [{1}, {2}]", commandName, commandArguments[0], commandArguments[1]);
+void TerminationGenerator::defineTerminationCondition(TerminationState state, int32_t reward, int32_t opposingReward, YAML::Node& conditionsNode) {
   TerminationConditionDefinition tcd;
-  tcd.commandName = commandName;
-  tcd.commandArguments = commandArguments;
+  tcd.conditionsNode = conditionsNode;
   tcd.state = state;
   tcd.reward = reward;
   tcd.opposingReward = opposingReward;

--- a/src/Griddly/Core/GDY/TerminationGenerator.hpp
+++ b/src/Griddly/Core/GDY/TerminationGenerator.hpp
@@ -13,7 +13,7 @@ class Player;
 
 class TerminationGenerator {
  public:
-  virtual void defineTerminationCondition(TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> commandArguments);
+  virtual void defineTerminationCondition(TerminationState state, int32_t reward, int32_t opposingReward, YAML::Node& conditionsNode);
   virtual std::shared_ptr<TerminationHandler> newInstance(std::shared_ptr<Grid> grid, std::vector<std::shared_ptr<Player>> players);
 
   virtual ~TerminationGenerator() = default;

--- a/src/Griddly/Core/GDY/TerminationHandler.cpp
+++ b/src/Griddly/Core/GDY/TerminationHandler.cpp
@@ -197,8 +197,8 @@ TerminationResult TerminationHandler::isTerminated() {
       return TerminationResult{
           true, playerTerminationRewards, playerTerminationStates};
     }
-    return TerminationResult();
   }
+  return TerminationResult();
 }
 
 }  // namespace griddly

--- a/src/Griddly/Core/GDY/TerminationHandler.cpp
+++ b/src/Griddly/Core/GDY/TerminationHandler.cpp
@@ -81,7 +81,7 @@ TerminationFunction TerminationHandler::instantiateTerminationCondition(Terminat
 
 void TerminationHandler::resolveTerminationConditions(TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> terminationVariables) {
   // Termination variables grows with the number of players in the game
-  auto resolvedVariableSets = findVariables(terminationVariables);
+  auto resolvedVariableSets = resolveVariables(terminationVariables);
 
   spdlog::debug("Resolving termination condition {0} {1} {2}", terminationVariables[0], commandName, terminationVariables[1]);
 
@@ -118,7 +118,7 @@ void TerminationHandler::addTerminationCondition(TerminationConditionDefinition 
   resolveTerminationConditions(terminationState, commandName, reward, opposingReward, commandArguments);
 }
 
-std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> TerminationHandler::findVariables(std::vector<std::string> variableArgs) {
+std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> TerminationHandler::resolveVariables(std::vector<std::string>& variableArgs) {
   std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolvedVariables;
 
   for (auto &variableArg : variableArgs) {

--- a/src/Griddly/Core/GDY/TerminationHandler.hpp
+++ b/src/Griddly/Core/GDY/TerminationHandler.hpp
@@ -44,7 +44,7 @@ class TerminationHandler {
   TerminationFunction instantiateTerminationCondition(TerminationState state, std::string commandName, uint32_t playerId, int32_t reward, int32_t opposingReward, std::vector<std::shared_ptr<int32_t>> variablePointers);
   void resolveTerminationConditions(TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> terminationVariables);
 
-  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> findVariables(std::vector<std::string> variables);
+  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolveVariables(std::vector<std::string>& variables);
   std::vector<TerminationFunction> terminationFunctions_;
 
   std::unordered_map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> availableVariables_;

--- a/src/Griddly/Core/GDY/TerminationHandler.hpp
+++ b/src/Griddly/Core/GDY/TerminationHandler.hpp
@@ -25,7 +25,6 @@ struct TerminationResult {
   std::unordered_map<uint32_t, TerminationState> playerStates{};
 };
 
-
 struct TerminationConditionDefinition {
   TerminationState state = TerminationState::NONE;
   int32_t reward = 0;
@@ -44,17 +43,30 @@ class TerminationHandler : ConditionResolver<TerminationFunction> {
   virtual ~TerminationHandler() = default;
   virtual TerminationResult isTerminated();
 
-  virtual void addTerminationCondition(TerminationConditionDefinition &terminationConditionDefinition);
+  virtual void addTerminationCondition(TerminationConditionDefinition& terminationConditionDefinition);
 
  private:
   TerminationFunction instantiateTerminationCondition(TerminationState state, uint32_t playerId, int32_t reward, int32_t opposingReward, YAML::Node& conditionsNode);
 
-  TerminationFunction resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node &conditionArgumentsNode) const override;
+  TerminationFunction resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node& conditionArgumentsNode) const override;
   TerminationFunction resolveAND(const std::vector<TerminationFunction>& conditionList) const override;
   TerminationFunction resolveOR(const std::vector<TerminationFunction>& conditionList) const override;
 
-  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolveVariables(CommandArguments &commandArguments) const;
+  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolveVariables(CommandArguments& commandArguments) const;
   std::vector<ResolvedTerminationCondition> resolvedTerminationConditions_;
+
+  std::string getTerminationStateString(TerminationState state) {
+    switch (state) {
+      case TerminationState::WIN:
+        return "WIN";
+      case TerminationState::LOSE:
+        return "LOSE";
+      case TerminationState::NONE:
+        return "NONE";
+      default:
+        return "NONE";
+    }
+  }
 
   std::unordered_map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> availableVariables_;
 

--- a/src/Griddly/Core/GDY/TerminationHandler.hpp
+++ b/src/Griddly/Core/GDY/TerminationHandler.hpp
@@ -5,8 +5,9 @@
 #include <vector>
 
 #include "../Grid.hpp"
+#include "ConditionResolver.hpp"
 
-#define TerminationFunction std::function<TerminationResult()>
+#define TerminationFunction std::function<std::unordered_map<uint32_t, bool>()>
 
 namespace griddly {
 
@@ -24,28 +25,36 @@ struct TerminationResult {
   std::unordered_map<uint32_t, TerminationState> playerStates{};
 };
 
+
 struct TerminationConditionDefinition {
   TerminationState state = TerminationState::NONE;
-  std::string commandName;
   int32_t reward = 0;
   int32_t opposingReward = 0;
-  std::vector<std::string> commandArguments{};
+  YAML::Node conditionsNode = YAML::Node(YAML::NodeType::Undefined);
 };
 
-class TerminationHandler {
+struct ResolvedTerminationCondition {
+  TerminationConditionDefinition definition{};
+  TerminationFunction conditionFunction;
+};
+
+class TerminationHandler : ConditionResolver<TerminationFunction> {
  public:
   TerminationHandler(std::shared_ptr<Grid> grid, std::vector<std::shared_ptr<Player>> players);
   virtual ~TerminationHandler() = default;
   virtual TerminationResult isTerminated();
 
-  virtual void addTerminationCondition(TerminationConditionDefinition terminationConditionDefinition);
+  virtual void addTerminationCondition(TerminationConditionDefinition &terminationConditionDefinition);
 
  private:
-  TerminationFunction instantiateTerminationCondition(TerminationState state, std::string commandName, uint32_t playerId, int32_t reward, int32_t opposingReward, std::vector<std::shared_ptr<int32_t>> variablePointers);
-  void resolveTerminationConditions(TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> terminationVariables);
+  TerminationFunction instantiateTerminationCondition(TerminationState state, uint32_t playerId, int32_t reward, int32_t opposingReward, YAML::Node& conditionsNode);
 
-  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolveVariables(std::vector<std::string>& variables);
-  std::vector<TerminationFunction> terminationFunctions_;
+  TerminationFunction resolveConditionArguments(const std::function<bool(int32_t, int32_t)> conditionFunction, YAML::Node &conditionArgumentsNode) const override;
+  TerminationFunction resolveAND(const std::vector<TerminationFunction>& conditionList) const override;
+  TerminationFunction resolveOR(const std::vector<TerminationFunction>& conditionList) const override;
+
+  std::vector<std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> resolveVariables(CommandArguments &commandArguments) const;
+  std::vector<ResolvedTerminationCondition> resolvedTerminationConditions_;
 
   std::unordered_map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> availableVariables_;
 

--- a/src/Griddly/Core/GDY/YAMLUtils.hpp
+++ b/src/Griddly/Core/GDY/YAMLUtils.hpp
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#define BehaviourCommandArguments std::unordered_map<std::string, YAML::Node>
+#define CommandArguments std::unordered_map<std::string, YAML::Node>
 
 namespace griddly {
 
@@ -21,8 +21,8 @@ inline std::vector<T> singleOrListNodeToList(YAML::Node singleOrList) {
   return values;
 }
 
-inline BehaviourCommandArguments singleOrListNodeToCommandArguments(YAML::Node singleOrList) {
-  BehaviourCommandArguments map;
+inline CommandArguments singleOrListNodeToCommandArguments(YAML::Node singleOrList) {
+  CommandArguments map;
   if (singleOrList.IsScalar()) {
     map["0"] = singleOrList;
   } else if (singleOrList.IsSequence()) {

--- a/src/Griddly/Core/GDY/YAMLUtils.hpp
+++ b/src/Griddly/Core/GDY/YAMLUtils.hpp
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#define CommandArguments std::unordered_map<std::string, YAML::Node>
+#define CommandArguments std::map<std::string, YAML::Node>
 
 namespace griddly {
 

--- a/src/Griddly/Core/Grid.cpp
+++ b/src/Griddly/Core/Grid.cpp
@@ -486,6 +486,8 @@ const std::unordered_map<std::string, std::vector<std::string>> Grid::getObjectV
 void Grid::initObject(std::string objectName, std::vector<std::string> variableNames) {
   objectIds_.insert({objectName, objectIds_.size()});
 
+  objectCounters_.insert({objectName, {{0, std::make_shared<int32_t>(0)}}});
+
   for (auto& variableName : variableNames) {
     objectVariableIds_.insert({variableName, objectVariableIds_.size()});
   }

--- a/tests/src/Griddly/Core/GDY/GDYFactoryTest.cpp
+++ b/tests/src/Griddly/Core/GDY/GDYFactoryTest.cpp
@@ -717,13 +717,11 @@ TEST(GDYFactoryTest, loadEnvironment_termination_v1) {
 
   auto environmentNode = loadFromStringAndGetNode(std::string(yamlString), "Environment");
 
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq("eq"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var1", "-10"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq(0), Eq(0), Eq(environmentNode["Termination"]["Lose"])))
       .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq("eq"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var2", "-10"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN), Eq(0), Eq(0), Eq(environmentNode["Termination"]["Win"])))
       .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN), Eq("gt"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var2", "10"})))
-      .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq("lt"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var3", "-1"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq(0), Eq(0), Eq(environmentNode["Termination"]["End"])))
       .Times(1);
 
   gdyFactory->loadEnvironment(environmentNode);
@@ -766,19 +764,19 @@ TEST(GDYFactoryTest, loadEnvironment_termination_v2) {
 
   auto environmentNode = loadFromStringAndGetNode(std::string(yamlString), "Environment");
 
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq("eq"), Eq(-5), Eq(5), Eq(std::vector<std::string>{"var1", "-10"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq(-5), Eq(5), Eq(environmentNode["Termination"]["Lose"][0]["Conditions"])))
       .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq("eq"), Eq(-15), Eq(15), Eq(std::vector<std::string>{"var2", "-10"})))
-      .Times(1);
-
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN), Eq("gte"), Eq(15), Eq(-15), Eq(std::vector<std::string>{"var2", "-10"})))
-      .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN), Eq("gt"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var2", "10"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::LOSE), Eq(-15), Eq(15), Eq(environmentNode["Termination"]["Lose"][1]["Conditions"])))
       .Times(1);
 
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq("eq"), Eq(-5), Eq(5), Eq(std::vector<std::string>{"var1", "-10"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN),  Eq(15), Eq(-15), Eq(environmentNode["Termination"]["Win"][0]["Conditions"])))
       .Times(1);
-  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq("lt"), Eq(0), Eq(0), Eq(std::vector<std::string>{"var3", "-1"})))
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::WIN), Eq(0), Eq(0), Eq(environmentNode["Termination"]["Win"][1]["Conditions"])))
+      .Times(1);
+
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq(-5), Eq(5), Eq(environmentNode["Termination"]["End"][0]["Conditions"])))
+      .Times(1);
+  EXPECT_CALL(*mockTerminationGeneratorPtr, defineTerminationCondition(Eq(TerminationState::NONE), Eq(0), Eq(0), Eq(environmentNode["Termination"]["End"][1]["Conditions"])))
       .Times(1);
 
   gdyFactory->loadEnvironment(environmentNode);

--- a/tests/src/Griddly/Core/GDY/Objects/ObjectTest.cpp
+++ b/tests/src/Griddly/Core/GDY/Objects/ObjectTest.cpp
@@ -377,7 +377,7 @@ std::shared_ptr<Object> setupObject(std::string objectname, std::unordered_map<s
   return setupObject(1, objectname, {0, 0}, initialVariables, mockGridPtr);
 }
 
-BehaviourResult addCommandsAndExecute(ActionBehaviourType type, std::shared_ptr<MockAction> action, std::string commandName, BehaviourCommandArguments commandArgumentMap, CommandList conditionalCommands, std::shared_ptr<Object> srcObjectPtr, std::shared_ptr<Object> dstObjectPtr) {
+BehaviourResult addCommandsAndExecute(ActionBehaviourType type, std::shared_ptr<MockAction> action, std::string commandName, CommandArguments commandArgumentMap, CommandList conditionalCommands, std::shared_ptr<Object> srcObjectPtr, std::shared_ptr<Object> dstObjectPtr) {
   switch (type) {
     case ActionBehaviourType::DESTINATION: {
       dstObjectPtr->addActionDstBehaviour(action->getActionName(), srcObjectPtr->getObjectName(), commandName, commandArgumentMap, conditionalCommands);
@@ -393,7 +393,7 @@ BehaviourResult addCommandsAndExecute(ActionBehaviourType type, std::shared_ptr<
   return {true};
 }
 
-BehaviourResult addCommandsAndExecute(ActionBehaviourType type, std::shared_ptr<MockAction> action, std::string commandName, BehaviourCommandArguments commandArgumentMap, std::shared_ptr<Object> srcObjectPtr, std::shared_ptr<Object> dstObjectPtr) {
+BehaviourResult addCommandsAndExecute(ActionBehaviourType type, std::shared_ptr<MockAction> action, std::string commandName, CommandArguments commandArgumentMap, std::shared_ptr<Object> srcObjectPtr, std::shared_ptr<Object> dstObjectPtr) {
   return addCommandsAndExecute(type, action, commandName, commandArgumentMap, {}, srcObjectPtr, dstObjectPtr);
 }
 

--- a/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
+++ b/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
@@ -61,6 +61,91 @@ TEST(TerminationHandlerTest, terminateOnPlayerScore) {
   ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1), Pair(2, -1)));
 }
 
+TEST(TerminationHandlerTest, terminateOnPlayerScore_list) {
+  auto mockGridPtr = std::make_shared<MockGrid>();
+  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
+  auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
+
+  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
+
+  EXPECT_CALL(*mockPlayer1Ptr, getId())
+      .WillRepeatedly(Return(1));
+
+  EXPECT_CALL(*mockPlayer2Ptr, getId())
+      .WillRepeatedly(Return(2));
+
+  EXPECT_CALL(*mockPlayer1Ptr, getScore())
+      .WillRepeatedly(Return(_V(10)));
+
+  EXPECT_CALL(*mockPlayer2Ptr, getScore())
+      .WillRepeatedly(Return(_V(5)));
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
+      .Times(1)
+      .WillOnce(ReturnRef(globalVariables));
+
+  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
+
+  auto conditionsNode = YAML::Load("[ eq: [ _score, 10 ], eq: [ _score, 10 ] ]");
+
+  TerminationConditionDefinition tcd;
+  tcd.conditionsNode = conditionsNode;
+  tcd.reward = 1;
+  tcd.opposingReward = -1;
+  tcd.state = TerminationState::WIN;
+  terminationHandlerPtr->addTerminationCondition(tcd);
+
+  auto terminationResult = terminationHandlerPtr->isTerminated();
+
+  ASSERT_TRUE(terminationResult.terminated);
+  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::WIN), Pair(2, TerminationState::LOSE)));
+  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1), Pair(2, -1)));
+}
+
+TEST(TerminationHandlerTest, terminateOnPlayerScore_singleton_list) {
+  auto mockGridPtr = std::make_shared<MockGrid>();
+  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
+  auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
+
+  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
+
+  EXPECT_CALL(*mockPlayer1Ptr, getId())
+      .WillRepeatedly(Return(1));
+
+  EXPECT_CALL(*mockPlayer2Ptr, getId())
+      .WillRepeatedly(Return(2));
+
+  EXPECT_CALL(*mockPlayer1Ptr, getScore())
+      .WillRepeatedly(Return(_V(10)));
+
+  EXPECT_CALL(*mockPlayer2Ptr, getScore())
+      .WillRepeatedly(Return(_V(5)));
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
+      .Times(1)
+      .WillOnce(ReturnRef(globalVariables));
+
+  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
+
+  auto conditionsNode = YAML::Load("- eq: [ _score, 10 ]");
+
+  TerminationConditionDefinition tcd;
+  tcd.conditionsNode = conditionsNode;
+  tcd.reward = 1;
+  tcd.opposingReward = -1;
+  tcd.state = TerminationState::WIN;
+  terminationHandlerPtr->addTerminationCondition(tcd);
+
+  auto terminationResult = terminationHandlerPtr->isTerminated();
+
+  ASSERT_TRUE(terminationResult.terminated);
+  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::WIN), Pair(2, TerminationState::LOSE)));
+  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1), Pair(2, -1)));
+}
+
+
 TEST(TerminationHandlerTest, terminateOnPlayerObjects0) {
   auto mockGridPtr = std::make_shared<MockGrid>();
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();

--- a/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
+++ b/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
@@ -46,11 +46,12 @@ TEST(TerminationHandlerTest, terminateOnPlayerScore) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ _score, 10 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"_score", "10"};
   tcd.state = TerminationState::WIN;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -95,12 +96,13 @@ TEST(TerminationHandlerTest, terminateOnPlayerObjects0) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ base:count, 0 ]");
+
   // Player with 0 bases will end the game and "lose"
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"base:count", "0"};
   tcd.state = TerminationState::LOSE;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -144,11 +146,12 @@ TEST(TerminationHandlerTest, terminateOnGlobalVariable) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ variable_name, 20 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"variable_name", "20"};
   terminationHandlerPtr->addTerminationCondition(tcd);
 
   auto terminationResult = terminationHandlerPtr->isTerminated();
@@ -195,13 +198,14 @@ TEST(TerminationHandlerTest, terminateOnPlayerGlobalVariable) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ variable_name, 0 ]");
+
   // Player with variable_name == 20 will win and the other player will lose
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
   tcd.state = TerminationState::WIN;
-  tcd.commandArguments = {"variable_name", "0"};
   terminationHandlerPtr->addTerminationCondition(tcd);
 
   auto terminationResult = terminationHandlerPtr->isTerminated();
@@ -246,11 +250,12 @@ TEST(TerminationHandlerTest, terminateOnMaxTicks) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ _steps, 100 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"_steps", "100"};
   tcd.state = TerminationState::NONE;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -282,11 +287,12 @@ TEST(TerminationHandlerTest, singlePlayer_differentId_win) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ environment_objects:count, 0 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"environment_objects:count", "0"};
   tcd.state = TerminationState::WIN;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -318,11 +324,13 @@ TEST(TerminationHandlerTest, singlePlayer_differentId_lose) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ environment_objects:count, 0 ]");
+
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = -1;
   tcd.opposingReward = 1;
-  tcd.commandArguments = {"environment_objects:count", "0"};
   tcd.state = TerminationState::LOSE;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -354,11 +362,12 @@ TEST(TerminationHandlerTest, singlePlayer_sameId_lose) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ player_objects:count, 0 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = -1;
   tcd.opposingReward = 1;
-  tcd.commandArguments = {"player_objects:count", "0"};
   tcd.state = TerminationState::LOSE;
   terminationHandlerPtr->addTerminationCondition(tcd);
 
@@ -390,11 +399,12 @@ TEST(TerminationHandlerTest, singlePlayer_sameId_win) {
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
+  auto conditionsNode = YAML::Load("eq: [ player_objects:count, 0 ]");
+
   TerminationConditionDefinition tcd;
-  tcd.commandName = "eq";
+  tcd.conditionsNode = conditionsNode;
   tcd.reward = 1;
   tcd.opposingReward = -1;
-  tcd.commandArguments = {"player_objects:count", "0"};
   tcd.state = TerminationState::WIN;
   terminationHandlerPtr->addTerminationCondition(tcd);
 

--- a/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
+++ b/tests/src/Griddly/Core/GDY/TerminationHandlerTest.cpp
@@ -15,15 +15,14 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::UnorderedElementsAre;
 
+#define _V(X) std::make_shared<int32_t>(X)
+
 namespace griddly {
 
 TEST(TerminationHandlerTest, terminateOnPlayerScore) {
   auto mockGridPtr = std::make_shared<MockGrid>();
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
   auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
-
-  auto player1Score = std::make_shared<int32_t>(10);
-  auto player2Score = std::make_shared<int32_t>(5);
 
   auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
 
@@ -34,10 +33,10 @@ TEST(TerminationHandlerTest, terminateOnPlayerScore) {
       .WillRepeatedly(Return(2));
 
   EXPECT_CALL(*mockPlayer1Ptr, getScore())
-      .WillRepeatedly(Return(player1Score));
+      .WillRepeatedly(Return(_V(10)));
 
   EXPECT_CALL(*mockPlayer2Ptr, getScore())
-      .WillRepeatedly(Return(player2Score));
+      .WillRepeatedly(Return(_V(5)));
 
   std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
   EXPECT_CALL(*mockGridPtr, getGlobalVariables())
@@ -67,11 +66,8 @@ TEST(TerminationHandlerTest, terminateOnPlayerObjects0) {
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
   auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
 
-  auto player1Score = std::make_shared<int32_t>(0);
-  auto player2Score = std::make_shared<int32_t>(0);
-
   auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
-  auto mockBaseCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{1, std::make_shared<int32_t>(3)}, {2, std::make_shared<int32_t>(0)}};
+  auto mockBaseCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{1, _V(3)}, {2, _V(0)}};
 
   EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("base")))
       .Times(1)
@@ -89,10 +85,10 @@ TEST(TerminationHandlerTest, terminateOnPlayerObjects0) {
       .WillRepeatedly(Return(2));
 
   EXPECT_CALL(*mockPlayer1Ptr, getScore())
-      .WillRepeatedly(Return(player1Score));
+      .WillRepeatedly(Return(_V(0)));
 
   EXPECT_CALL(*mockPlayer2Ptr, getScore())
-      .WillRepeatedly(Return(player2Score));
+      .WillRepeatedly(Return(_V(0)));
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
@@ -118,15 +114,10 @@ TEST(TerminationHandlerTest, terminateOnGlobalVariable) {
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
   auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
 
-  auto player1Score = std::make_shared<int32_t>(0);
-  auto player2Score = std::make_shared<int32_t>(0);
-
-  auto globalVariablePtr = std::make_shared<int32_t>(20);
-
   auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
 
   std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables;
-  globalVariables["variable_name"].insert({0, globalVariablePtr});
+  globalVariables["variable_name"].insert({0, _V(20)});
 
   EXPECT_CALL(*mockGridPtr, getGlobalVariables())
       .Times(1)
@@ -139,10 +130,10 @@ TEST(TerminationHandlerTest, terminateOnGlobalVariable) {
       .WillRepeatedly(Return(2));
 
   EXPECT_CALL(*mockPlayer1Ptr, getScore())
-      .WillRepeatedly(Return(player1Score));
+      .WillRepeatedly(Return(_V(0)));
 
   EXPECT_CALL(*mockPlayer2Ptr, getScore())
-      .WillRepeatedly(Return(player2Score));
+      .WillRepeatedly(Return(_V(0)));
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
@@ -166,19 +157,12 @@ TEST(TerminationHandlerTest, terminateOnPlayerGlobalVariable) {
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
   auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
 
-  auto player1Score = std::make_shared<int32_t>(0);
-  auto player2Score = std::make_shared<int32_t>(0);
-
-  auto player0Variable = std::make_shared<int32_t>(0);
-  auto player1Variable = std::make_shared<int32_t>(0);
-  auto player2Variable = std::make_shared<int32_t>(10);
-
   auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
 
   std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables;
-  globalVariables["variable_name"].insert({0, player0Variable});
-  globalVariables["variable_name"].insert({1, player1Variable});
-  globalVariables["variable_name"].insert({2, player2Variable});
+  globalVariables["variable_name"].insert({0, _V(0)});
+  globalVariables["variable_name"].insert({1, _V(0)});
+  globalVariables["variable_name"].insert({2, _V(10)});
 
   EXPECT_CALL(*mockGridPtr, getGlobalVariables())
       .Times(1)
@@ -191,10 +175,10 @@ TEST(TerminationHandlerTest, terminateOnPlayerGlobalVariable) {
       .WillRepeatedly(Return(2));
 
   EXPECT_CALL(*mockPlayer1Ptr, getScore())
-      .WillRepeatedly(Return(player1Score));
+      .WillRepeatedly(Return(_V(0)));
 
   EXPECT_CALL(*mockPlayer2Ptr, getScore())
-      .WillRepeatedly(Return(player2Score));
+      .WillRepeatedly(Return(_V(0)));
 
   auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
 
@@ -220,11 +204,6 @@ TEST(TerminationHandlerTest, terminateOnMaxTicks) {
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
   auto mockPlayer2Ptr = std::make_shared<MockPlayer>();
 
-  auto player1Score = std::make_shared<int32_t>(0);
-  auto player2Score = std::make_shared<int32_t>(0);
-
-  auto tickCounter = std::make_shared<int32_t>(100);
-
   auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr, mockPlayer2Ptr};
 
   EXPECT_CALL(*mockPlayer1Ptr, getId())
@@ -234,14 +213,14 @@ TEST(TerminationHandlerTest, terminateOnMaxTicks) {
       .WillRepeatedly(Return(2));
 
   EXPECT_CALL(*mockPlayer1Ptr, getScore())
-      .WillRepeatedly(Return(player1Score));
+      .WillRepeatedly(Return(_V(0)));
 
   EXPECT_CALL(*mockPlayer2Ptr, getScore())
-      .WillRepeatedly(Return(player2Score));
+      .WillRepeatedly(Return(_V(0)));
 
   EXPECT_CALL(*mockGridPtr, getTickCount())
       .Times(1)
-      .WillOnce(Return(tickCounter));
+      .WillOnce(Return(_V(100)));
 
   std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
   EXPECT_CALL(*mockGridPtr, getGlobalVariables())
@@ -266,7 +245,7 @@ TEST(TerminationHandlerTest, terminateOnMaxTicks) {
   ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 0), Pair(2, 0)));
 }
 
-TEST(TerminationHandlerTest, singlePlayer_differentId_win) {
+TEST(TerminationHandlerTest, singlePlayer_objectCounter_lose) {
   auto mockGridPtr = std::make_shared<MockGrid>();
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
 
@@ -275,82 +254,7 @@ TEST(TerminationHandlerTest, singlePlayer_differentId_win) {
   EXPECT_CALL(*mockPlayer1Ptr, getId())
       .WillRepeatedly(Return(1));
 
-  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
-  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
-      .Times(1)
-      .WillOnce(ReturnRef(globalVariables));
-
-  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{0, std::make_shared<int32_t>(0)}};
-  EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("environment_objects")))
-      .Times(1)
-      .WillOnce(Return(playerObjectCounter));
-
-  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
-
-  auto conditionsNode = YAML::Load("eq: [ environment_objects:count, 0 ]");
-
-  TerminationConditionDefinition tcd;
-  tcd.conditionsNode = conditionsNode;
-  tcd.reward = 1;
-  tcd.opposingReward = -1;
-  tcd.state = TerminationState::WIN;
-  terminationHandlerPtr->addTerminationCondition(tcd);
-
-  auto terminationResult = terminationHandlerPtr->isTerminated();
-
-  ASSERT_TRUE(terminationResult.terminated);
-  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::WIN)));
-  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, -1)));
-}
-
-TEST(TerminationHandlerTest, singlePlayer_differentId_lose) {
-  auto mockGridPtr = std::make_shared<MockGrid>();
-  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
-
-  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr};
-
-  EXPECT_CALL(*mockPlayer1Ptr, getId())
-      .WillRepeatedly(Return(1));
-
-  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
-  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
-      .Times(1)
-      .WillOnce(ReturnRef(globalVariables));
-
-  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{0, std::make_shared<int32_t>(0)}};
-  EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("environment_objects")))
-      .Times(1)
-      .WillOnce(Return(playerObjectCounter));
-
-  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
-
-  auto conditionsNode = YAML::Load("eq: [ environment_objects:count, 0 ]");
-
-
-  TerminationConditionDefinition tcd;
-  tcd.conditionsNode = conditionsNode;
-  tcd.reward = -1;
-  tcd.opposingReward = 1;
-  tcd.state = TerminationState::LOSE;
-  terminationHandlerPtr->addTerminationCondition(tcd);
-
-  auto terminationResult = terminationHandlerPtr->isTerminated();
-
-  ASSERT_TRUE(terminationResult.terminated);
-  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::LOSE)));
-  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1)));
-}
-
-TEST(TerminationHandlerTest, singlePlayer_sameId_lose) {
-  auto mockGridPtr = std::make_shared<MockGrid>();
-  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
-
-  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr};
-
-  EXPECT_CALL(*mockPlayer1Ptr, getId())
-      .WillRepeatedly(Return(1));
-
-  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{1, std::make_shared<int32_t>(0)}};
+  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{0, _V(0)}, {1, _V(0)}};
   EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("player_objects")))
       .Times(1)
       .WillOnce(Return(playerObjectCounter));
@@ -378,7 +282,7 @@ TEST(TerminationHandlerTest, singlePlayer_sameId_lose) {
   ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, -1)));
 }
 
-TEST(TerminationHandlerTest, singlePlayer_sameId_win) {
+TEST(TerminationHandlerTest, singlePlayer_objectCounter_win) {
   auto mockGridPtr = std::make_shared<MockGrid>();
   auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
 
@@ -387,7 +291,7 @@ TEST(TerminationHandlerTest, singlePlayer_sameId_win) {
   EXPECT_CALL(*mockPlayer1Ptr, getId())
       .WillRepeatedly(Return(1));
 
-  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{1, std::make_shared<int32_t>(0)}};
+  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{{0, _V(0)}, {1, _V(0)}};
   EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("player_objects")))
       .Times(1)
       .WillOnce(Return(playerObjectCounter));
@@ -413,6 +317,134 @@ TEST(TerminationHandlerTest, singlePlayer_sameId_win) {
   ASSERT_TRUE(terminationResult.terminated);
   ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::WIN)));
   ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1)));
+}
+
+TEST(TerminationHandlerTest, multiPlayer_objectCounter_lose) {
+  auto mockGridPtr = std::make_shared<MockGrid>();
+  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
+
+  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr};
+
+  EXPECT_CALL(*mockPlayer1Ptr, getId())
+      .WillRepeatedly(Return(1));
+
+  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{
+      {0, _V(0)},
+      {1, _V(0)},
+      {2, _V(5)},
+      {3, _V(5)}};
+  EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("player_objects")))
+      .Times(1)
+      .WillOnce(Return(playerObjectCounter));
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
+      .Times(1)
+      .WillOnce(ReturnRef(globalVariables));
+
+  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
+
+  auto conditionsNode = YAML::Load("eq: [ player_objects:count, 0 ]");
+
+  TerminationConditionDefinition tcd;
+  tcd.conditionsNode = conditionsNode;
+  tcd.reward = -1;
+  tcd.opposingReward = 1;
+  tcd.state = TerminationState::LOSE;
+  terminationHandlerPtr->addTerminationCondition(tcd);
+
+  auto terminationResult = terminationHandlerPtr->isTerminated();
+
+  ASSERT_TRUE(terminationResult.terminated);
+  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::LOSE), Pair(2, TerminationState::WIN), Pair(3, TerminationState::WIN)));
+  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, -1), Pair(2, 1), Pair(3, 1)));
+}
+
+TEST(TerminationHandlerTest, multiPlayer_objectCounter_multipleWinners) {
+  auto mockGridPtr = std::make_shared<MockGrid>();
+  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
+
+  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr};
+
+  EXPECT_CALL(*mockPlayer1Ptr, getId())
+      .WillRepeatedly(Return(1));
+
+  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{
+      {0, _V(0)},
+      {1, _V(0)},
+      {2, _V(0)},
+      {3, _V(5)}};
+  EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("player_objects")))
+      .Times(1)
+      .WillOnce(Return(playerObjectCounter));
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
+      .Times(1)
+      .WillOnce(ReturnRef(globalVariables));
+
+  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
+
+  auto conditionsNode = YAML::Load("eq: [ player_objects:count, 0 ]");
+
+  TerminationConditionDefinition tcd;
+  tcd.conditionsNode = conditionsNode;
+  tcd.reward = 1;
+  tcd.opposingReward = -1;
+  tcd.state = TerminationState::WIN;
+  terminationHandlerPtr->addTerminationCondition(tcd);
+
+  auto terminationResult = terminationHandlerPtr->isTerminated();
+
+  ASSERT_TRUE(terminationResult.terminated);
+  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::WIN), Pair(2, TerminationState::WIN), Pair(3, TerminationState::LOSE)));
+  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, 1), Pair(2, 1), Pair(3, -1)));
+}
+
+TEST(TerminationHandlerTest, multiPlayer_objectCounter_multipleConditions) {
+  auto mockGridPtr = std::make_shared<MockGrid>();
+  auto mockPlayer1Ptr = std::make_shared<MockPlayer>();
+
+  auto players = std::vector<std::shared_ptr<Player>>{mockPlayer1Ptr};
+
+  EXPECT_CALL(*mockPlayer1Ptr, getId())
+      .WillRepeatedly(Return(1));
+
+  auto playerObjectCounter = std::unordered_map<uint32_t, std::shared_ptr<int32_t>>{
+      {0, _V(0)},
+      {1, _V(0)},
+      {2, _V(0)},
+      {3, _V(5)}};
+  EXPECT_CALL(*mockGridPtr, getObjectCounter(Eq("player_objects")))
+      .Times(1)
+      .WillOnce(Return(playerObjectCounter));
+
+  std::map<std::string, std::unordered_map<uint32_t, std::shared_ptr<int32_t>>> globalVariables{
+      {"player_var", {{0, _V(0)}, {1, _V(0)}, {2, _V(2)}, {3, _V(5)}}}};
+  EXPECT_CALL(*mockGridPtr, getGlobalVariables())
+      .Times(1)
+      .WillOnce(ReturnRef(globalVariables));
+
+  auto terminationHandlerPtr = std::make_shared<TerminationHandler>(mockGridPtr, players);
+
+  auto conditionsNode = YAML::Load(R"(
+and: 
+  - eq: [ player_objects:count, 0 ]
+  - gt: [ player_var, 1 ]
+)");
+
+  TerminationConditionDefinition tcd;
+  tcd.conditionsNode = conditionsNode;
+  tcd.reward = 1;
+  tcd.opposingReward = -1;
+  tcd.state = TerminationState::WIN;
+  terminationHandlerPtr->addTerminationCondition(tcd);
+
+  auto terminationResult = terminationHandlerPtr->isTerminated();
+
+  ASSERT_TRUE(terminationResult.terminated);
+  ASSERT_THAT(terminationResult.playerStates, UnorderedElementsAre(Pair(1, TerminationState::LOSE), Pair(2, TerminationState::WIN), Pair(3, TerminationState::LOSE)));
+  ASSERT_THAT(terminationResult.rewards, UnorderedElementsAre(Pair(1, -1), Pair(2, 1), Pair(3, -1)));
 }
 
 }  // namespace griddly

--- a/tests/src/Griddly/Core/TestUtils/common.hpp
+++ b/tests/src/Griddly/Core/TestUtils/common.hpp
@@ -89,7 +89,7 @@ std::shared_ptr<MockAction> static mockAction(std::string actionName, std::share
   return mockActionPtr;
 }
 
-bool static commandArgumentsEqual(BehaviourCommandArguments a, BehaviourCommandArguments b) {
+bool static commandArgumentsEqual(CommandArguments a, CommandArguments b) {
   for (auto& it : a) {
     auto key = it.first;
     auto node = it.second;
@@ -101,7 +101,7 @@ bool static commandArgumentsEqual(BehaviourCommandArguments a, BehaviourCommandA
   return true;
 }
 
-bool static commandListEqual(std::vector<std::pair<std::string, BehaviourCommandArguments>> a, std::vector<std::pair<std::string, BehaviourCommandArguments>> b) {
+bool static commandListEqual(std::vector<std::pair<std::string, CommandArguments>> a, std::vector<std::pair<std::string, CommandArguments>> b) {
 
   for(int i = 0; i<a.size(); i++) {
     auto pairA = a[i];

--- a/tests/src/Mocks/Griddly/Core/GDY/MockTerminationGenerator.hpp
+++ b/tests/src/Mocks/Griddly/Core/GDY/MockTerminationGenerator.hpp
@@ -10,7 +10,7 @@ class MockTerminationGenerator : public TerminationGenerator {
  public:
   MockTerminationGenerator() : TerminationGenerator(){};
 
-  MOCK_METHOD(void, defineTerminationCondition, (TerminationState state, std::string commandName, int32_t reward, int32_t opposingReward, std::vector<std::string> commandParameters), ());
+  MOCK_METHOD(void, defineTerminationCondition, (TerminationState state, int32_t reward, int32_t opposingReward, YAML::Node& conditionNode), ());
   MOCK_METHOD(std::shared_ptr<TerminationHandler>, newInstance, (std::shared_ptr<Grid> grid, std::vector<std::shared_ptr<Player>> players), ());
 };
 }  // namespace griddly

--- a/tests/src/Mocks/Griddly/Core/GDY/Objects/MockObject.hpp
+++ b/tests/src/Mocks/Griddly/Core/GDY/Objects/MockObject.hpp
@@ -39,7 +39,7 @@ class MockObject : public Object {
   MOCK_METHOD(std::unordered_set<std::string>, getAvailableActionNames, (), (const));
   MOCK_METHOD((std::unordered_map<std::string, std::shared_ptr<int32_t>>), getAvailableVariables, (), (const));
 
-  MOCK_METHOD(void, addActionSrcBehaviour, (std::string action, std::string destinationObjectName, std::string commandName, (BehaviourCommandArguments commandArguments), (CommandList conditionalCommands)), (override));
-  MOCK_METHOD(void, addActionDstBehaviour, (std::string action, std::string sourceObjectName, std::string commandName, (BehaviourCommandArguments commandArguments), (CommandList conditionalCommands)), (override));
+  MOCK_METHOD(void, addActionSrcBehaviour, (std::string action, std::string destinationObjectName, std::string commandName, (CommandArguments commandArguments), (CommandList conditionalCommands)), (override));
+  MOCK_METHOD(void, addActionDstBehaviour, (std::string action, std::string sourceObjectName, std::string commandName, (CommandArguments commandArguments), (CommandList conditionalCommands)), (override));
 };
 }  // namespace griddly


### PR DESCRIPTION
Extends #185 and fixes #161 

Can now use `and` and `or` statements in terminations:

As an example:
```
Termination:
  Win:
    and: 
      - eq: [x, 0]
      - lt: [b, 100]
```