### PR TITLE
Fix rllib env properties and cache bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,20 +84,20 @@ list(REMOVE_DUPLICATES GRIDDLY_INCLUDE_DIRS)
 
 if(WASM)
     list(
-        REMOVE_ITEM 
-        GRIDDLY_SOURCES 
+        REMOVE_ITEM
+        GRIDDLY_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Griddly/Core/Observers/SpriteObserver.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/Griddly/Core/Observers/BlockObserver.cpp 
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Griddly/Core/Observers/BlockObserver.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Griddly/Core/Observers/IsometricSpriteObserver.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Griddly/Core/Observers/VulkanGridObserver.cpp
     )
 
     list(
-        FILTER 
-        GRIDDLY_SOURCES 
+        FILTER
+        GRIDDLY_SOURCES
         EXCLUDE
         REGEX
-        "src/Griddly/Core/Observers/Vulkan/.*" 
+        "src/Griddly/Core/Observers/Vulkan/.*"
     )
 endif()
 
@@ -105,7 +105,7 @@ endif()
 # Compile shaders and copy them into resources directory in build output
 if(NOT WASM)
     message(STATUS "Compiling shaders...")
-    find_package(Vulkan REQUIRED FATAL_ERROR)
+    find_package(Vulkan REQUIRED)
 
     if(MSVC)
         execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/compile_shaders.bat RESULT_VARIABLE rv)
@@ -130,7 +130,7 @@ if(WASM)
 
     add_executable(griddlyjs ${JIDDLY_SOURCES} )
     target_link_libraries(griddlyjs PRIVATE ${BINARY} yaml-cpp glm)
-    
+
     # These properties specify what kind of Emscripten build to perform and are assigned to our 'a-simple-triangle' executable target.
     set_target_properties(
         griddlyjs

--- a/python/griddly/GymWrapper.py
+++ b/python/griddly/GymWrapper.py
@@ -125,19 +125,19 @@ class GymWrapper(gym.Env):
 
     @property
     def player_count(self):
-        if not self._cache.player_count:
+        if self._cache.player_count is None:
             self._cache.player_count = self.gdy.get_player_count()
         return self._cache.player_count
 
     @property
     def level_count(self):
-        if not self._cache.level_count:
+        if self._cache.level_count is None:
             self._cache.level_count = self.gdy.get_level_count()
         return self._cache.level_count
 
     @property
     def avatar_object(self):
-        if not self._cache.avatar_object:
+        if self._cache.avatar_object is None:
             self._cache.avatar_object = self.gdy.get_avatar_object()
         return self._cache.avatar_object
 
@@ -147,13 +147,13 @@ class GymWrapper(gym.Env):
 
     @property
     def action_input_mappings(self):
-        if not self._cache.action_input_mappings:
+        if self._cache.action_input_mappings is None:
             self._cache.action_input_mappings = self.gdy.get_action_input_mappings()
         return self._cache.action_input_mappings
 
     @property
     def action_names(self):
-        if not self._cache.action_names:
+        if self._cache.action_names is None:
             self._cache.action_names = self.gdy.get_action_names()
         return self._cache.action_names
 
@@ -167,25 +167,25 @@ class GymWrapper(gym.Env):
 
     @property
     def object_names(self):
-        if not self._cache.object_names:
+        if self._cache.object_names is None:
             self._cache.object_names = self.game.get_object_names()
         return self._cache.object_names
 
     @property
     def variable_names(self):
-        if not self._cache.variable_names:
+        if self._cache.variable_names is None:
             self._cache.variable_names = self.game.get_object_variable_names()
         return self._cache.variable_names
 
     @property
     def _vector2rgb(self):
-        if not self._cache.vector2rgb:
+        if self._cache.vector2rgb is None:
             self._cache.vector2rgb = Vector2RGB(10, len(self.object_names))
         return self._cache.vector2rgb
 
     @property
     def global_observation_space(self):
-        if not self._cache.global_observation_space:
+        if self._cache.global_observation_space is None:
             self._cache.global_observation_space = self._get_obs_space(
                 self.game.get_global_observation_description(),
                 self._global_observer_type
@@ -194,7 +194,7 @@ class GymWrapper(gym.Env):
 
     @property
     def player_observation_space(self):
-        if not self._cache.player_observation_space:
+        if self._cache.player_observation_space is None:
             if self.player_count == 1:
                 self._cache.player_observation_space = self._get_obs_space(
                     self._players[0].get_observation_description(),
@@ -219,25 +219,25 @@ class GymWrapper(gym.Env):
 
     @property
     def max_action_ids(self):
-        if not self._cache.max_action_ids:
+        if self._cache.max_action_ids is None:
             self._init_action_variable_cache()
         return self._cache.max_action_ids
 
     @property
     def num_action_ids(self):
-        if not self._cache.num_action_ids:
+        if self._cache.num_action_ids is None:
             self._init_action_variable_cache()
         return self._cache.num_action_ids
 
     @property
     def action_space_parts(self):
-        if not self._cache.action_space_parts:
+        if self._cache.action_space_parts is None:
             self._init_action_variable_cache()
         return self._cache.action_space_parts
 
     @property
     def action_space(self):
-        if not self._cache.action_space:
+        if self._cache.action_space is None:
             self._cache.action_space = self._create_action_space()
         return self._cache.action_space
 

--- a/python/griddly/GymWrapper.py
+++ b/python/griddly/GymWrapper.py
@@ -17,8 +17,8 @@ class _GymWrapperCache:
         self.player_observation_space = None
         self.global_observation_space = None
         self.action_space_parts = None
-        self.max_action_ids = 0
-        self.num_action_ids = {}
+        self.max_action_ids = None
+        self.num_action_ids = None
         self.action_space = None
         self.object_names = None
         self.variable_names = None
@@ -517,14 +517,18 @@ class GymWrapper(gym.Env):
         if self.action_count > 1:
             self._cache.action_space_parts.append(self.action_count)
 
+        self._cache.num_action_ids = {}
+        max_action_ids = 0
+
         for action_name, mapping in sorted(self.action_input_mappings.items()):
             if not mapping["Internal"]:
                 num_action_ids = len(mapping["InputMappings"]) + 1
                 self._cache.num_action_ids[action_name] = num_action_ids
-                if self._cache.max_action_ids < num_action_ids:
-                    self._cache.max_action_ids = num_action_ids
+                if max_action_ids < num_action_ids:
+                    max_action_ids = num_action_ids
 
-        self._cache.action_space_parts.append(self.max_action_ids)
+        self._cache.max_action_ids = max_action_ids
+        self._cache.action_space_parts.append(max_action_ids)
 
     def clone(self):
         """

--- a/python/griddly/GymWrapper.py
+++ b/python/griddly/GymWrapper.py
@@ -203,7 +203,6 @@ class GymWrapper(gym.Env):
             else:
                 observation_spaces = []
                 for p in range(self.player_count):
-                    observation_description = self._players[p].get_observation_description()
                     observation_spaces.append(
                         self._get_obs_space(
                             self._players[p].get_observation_description(),

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,4 +7,4 @@ matplotlib>=3.3.3
 pyglet
 pytest>=6.2.1
 black
-ray[rllib]==1.13.0
+ray[rllib]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,3 +8,4 @@ pyglet
 pytest>=6.2.1
 black
 ray[rllib]
+torch

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,4 +7,4 @@ matplotlib>=3.3.3
 pyglet
 pytest>=6.2.1
 black
-
+ray[rllib]==1.13.0

--- a/python/tests/rllib_test.py
+++ b/python/tests/rllib_test.py
@@ -1,0 +1,61 @@
+import pytest
+import os
+import sys
+import ray
+
+from ray import tune
+from ray.rllib.agents.impala import ImpalaTrainer
+from ray.rllib.models import ModelCatalog
+from ray.tune.registry import register_env
+
+from griddly import gd
+from griddly.util.rllib.torch import GAPAgent
+from griddly.util.rllib.environment.core import RLlibEnv
+
+
+def test_rllib_env():
+    sep = os.pathsep
+    os.environ['PYTHONPATH'] = sep.join(sys.path)
+
+    ray.init(num_gpus=0)
+
+    env_name = "ray-griddly-env"
+
+    register_env(env_name, RLlibEnv)
+    ModelCatalog.register_custom_model("GAP", GAPAgent)
+
+    max_training_steps = 1
+
+    config = {
+        'framework': 'torch',
+        'num_workers': 2,
+        'num_envs_per_worker': 1,
+        'num_gpus': 0,
+        'model': {
+            'custom_model': 'GAP',
+            'custom_model_config': {}
+        },
+        'env': env_name,
+        'env_config': {
+            'random_level_on_reset': True,
+            'yaml_file': 'Single-Player/GVGAI/clusters_partially_observable.yaml',
+            'global_observer_type': gd.ObserverType.VECTOR,
+            'max_steps': 100,
+        },
+        'entropy_coeff_schedule': [
+            [0, 0.01],
+            [max_training_steps, 0.0]
+        ],
+        'lr_schedule': [
+            [0, 0.0005],
+            [max_training_steps, 0.0]
+        ]
+    }
+
+    stop = {
+        "timesteps_total": max_training_steps,
+    }
+
+    result = tune.run(ImpalaTrainer, config=config, stop=stop)
+
+    assert result is not None

--- a/python/tests/rllib_test.py
+++ b/python/tests/rllib_test.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 import sys
 import ray
@@ -28,7 +27,7 @@ def test_rllib_env():
 
     config = {
         'framework': 'torch',
-        'num_workers': 2,
+        'num_workers': 1,
         'num_envs_per_worker': 1,
         'num_gpus': 0,
         'model': {


### PR DESCRIPTION
Fix rllib env action and observation spaces by converting them to properties. Fixes a rare infinite loop bug with action cache initialization when an environment has no actions.

Also, uses the lazy eval paradigm to not evaluate them on every call and adds a simple smoke test which checks that the rllib env does not crash.

Removes the `FATAL_ERROR` keyword from `find_package` as it is an invalid option and from `cmake 3.24` onwards this causes `cmake` to crash.