### PR TITLE
New Gym API compatibility updates

### DIFF
--- a/python/examples/Box Carry/main.py
+++ b/python/examples/Box Carry/main.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
         global_observer_type=gd.ObserverType.BLOCK_2D,
     )
 
-    env.reset(level_id=0)
+    env.reset(options={"level_id": 0})
     env.render()
     # Send the same actions to both agents
     env.step([3, 3])

--- a/python/examples/Level Design/main.py
+++ b/python/examples/Level Design/main.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     image_renderer = RenderToFile()
 
     for i in range(3):
-        env.reset(level_id=i)
+        env.reset(options={"level_id": i})
         obs = env.render(mode="rgb_array", observer="global")
         image_renderer.render(obs, f"level_{i}_global.png")
         if i > 0:
@@ -34,7 +34,7 @@ c c . . . c c c . c c c c c c . . c c . c c . . . c c . c c . . . c c . c c . . 
 c c . . . . c c . c c . . . c c . c c . c c . . . c c . c c . . . c c . c c . . . . . . . . . c c . . . .  
 . c c c c c c . . c c . . . c c . c c . c c c c c c . . c c c c c c . . c c c c c c c . . . . c c . . . .
  """
-    env.reset(level_string=level_string)
+    env.reset(options={"level_string": level_string})
     obs = env.render(mode="rgb_array", observer="global")
     image_renderer.render(obs, f"custom_level_global.png")
     obs = env.render(mode="rgb_array", observer=0)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20.3
-gym==0.22.0
+gym>=0.25.0,<1.0.0
 pyyaml>=5.3.1
 imageio>=2.9.0
 pygame>=2.0.0

--- a/python/tests/reset_test.py
+++ b/python/tests/reset_test.py
@@ -65,7 +65,7 @@ def test_reset_SinglePlayer_Global(test_name):
     """
 
     env = build_env(test_name, "tests/gdy/test_step_SinglePlayer_SingleActionType.yaml")
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]
@@ -79,7 +79,7 @@ def test_reset_SinglePlayer_Global(test_name):
     assert env.action_space.shape == ()
     assert env.action_space.n == 5
 
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]
@@ -143,7 +143,7 @@ def test_reset_MultiPlayer_Global(test_name):
     """
 
     env = build_env(test_name, "tests/gdy/test_step_MultiPlayer_SingleActionType.yaml")
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]
@@ -159,7 +159,7 @@ def test_reset_MultiPlayer_Global(test_name):
         assert isinstance(env.action_space[p], Discrete)
         assert env.action_space[p].n == 5
 
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]
@@ -193,7 +193,7 @@ def test_reset_MultiPlayer_MultiActionSpace(test_name):
     env = build_env(
         test_name, "tests/gdy/test_step_MultiPlayer_MultipleActionType.yaml"
     )
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]
@@ -208,7 +208,7 @@ def test_reset_MultiPlayer_MultiActionSpace(test_name):
         assert env.action_space[p].shape == (2,)
         assert np.all(env.action_space[p].nvec == [2, 5])
 
-    obs = env.reset(global_observations=True)
+    obs = env.reset(options={"global_observations": True})
 
     global_obs = obs["global"]
     player_obs = obs["player"]


### PR DESCRIPTION
This work is to fix #196 and fix #212.

Most of superficial work is done, what remains is to properly test if everything works as expected.
One thing that still is not really properly implemented is returning `truncated` as `True` if the env times out, etc. Currently it’s always `False`.

As mentioned in #196, seeding before proper reset happens might crash, that would mean that the C++ part has to updated though and for now I don’t want to mess around with that.

One optional thing is to support the old `step` return of `obs, reward, done, info` but I don’t know if it’s worth it.
Documentation has to be updated of course.