### PR TITLE
sort variableNames to provide consistent observations

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Poetry install
         run: |
           cd python
+          /opt/python/$PYBIN/bin/poetry lock
           /opt/python/$PYBIN/bin/poetry install
 
       # Run python tests
@@ -245,6 +246,7 @@ jobs:
       - name: Poetry install
         run: |
           cd python
+          poetry lock
           poetry install
 
       # Run python tests

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -95,7 +95,7 @@ jobs:
 
       # Install Ninja
       - name: Install Ninja
-        run: sudo apt-get install -y ninja-build
+        run: apt-get install -y ninja-build
 
       # Configure conan for release build
       - name: Build

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -178,6 +178,7 @@ jobs:
       - name: Poetry install
         run: |
           cd python
+          poetry lock
           poetry install
 
       # Run python tests

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -93,6 +93,10 @@ jobs:
         run: |
           /opt/python/$PYBIN/bin/pip install poetry cmake conan==1.59.0
 
+      # Install Ninja
+      - name: Install Ninja
+        run: sudo apt-get install -y ninja-build
+
       # Configure conan for release build
       - name: Build
         run: |
@@ -152,7 +156,7 @@ jobs:
         id: py
         with:
           python-version: ${{ matrix.windows_config.python-version }}
-      
+
       # Setup MSVC
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -95,7 +95,7 @@ jobs:
 
       # Install Ninja
       - name: Install Ninja
-        run: sudo apt-get install -y ninja-build
+        run: yum install -y ninja-build
 
       # Configure conan for release build
       - name: Build

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,7 +1,5 @@
 ./configure.sh
 
-conan profile update settings.compiler.libcxx=libstdc++11 default
-
 conan install deps/conanfile.txt --profile default \
  --profile deps/build.profile \
  -s build_type=Release --build missing -if build

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,14 @@
+./configure.sh
+
+conan profile update settings.compiler.libcxx=libstdc++11 default
+
+conan install deps/conanfile.txt --profile default \
+ --profile deps/build.profile \
+ -s build_type=Release --build missing -if build
+
+cmake . -B build -GNinja -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
+
+cmake --build build --config Release
+
+pip install -e python

--- a/build_release.sh
+++ b/build_release.sh
@@ -11,4 +11,3 @@ cmake . -B build -GNinja -DCMAKE_BUILD_TYPE=Release \
 
 cmake --build build --config Release
 
-pip install -e python

--- a/deps/build.profile
+++ b/deps/build.profile
@@ -3,6 +3,3 @@ ninja/1.11.1
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
-
-[settings]
-compiler.libcxx=libstdc++11

--- a/deps/build.profile
+++ b/deps/build.profile
@@ -3,3 +3,6 @@ ninja/1.11.1
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
+
+[settings]
+compiler.libcxx=libstdc++11

--- a/js/griddlyjs-app/package-lock.json
+++ b/js/griddlyjs-app/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "griddlyjs-app",
-      "version": "1.6.3",
+      "version": "1.6.7",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/js/griddlyjs-app/src/renderer/Sprite2DRenderer.js
+++ b/js/griddlyjs-app/src/renderer/Sprite2DRenderer.js
@@ -123,7 +123,7 @@ class Sprite2DRenderer extends RendererBase {
 
       sprite.setDisplaySize(
         this.renderConfig.TileSize,
-        this.renderConfig.TileSize 
+        this.renderConfig.TileSize
       );
     }
 
@@ -141,7 +141,12 @@ class Sprite2DRenderer extends RendererBase {
     if (!sprite) {
       return;
     }
-    const objectTemplate = this.objectTemplates[objectTemplateName];
+    var objectTemplate = this.objectTemplates[objectTemplateName];
+    if (!objectTemplate) {
+      // pick the first one
+      objectTemplate = this.objectTemplates[Object.keys(this.objectTemplates)[0]];
+    }
+
 
     sprite.setPosition(this.getCenteredX(x), this.getCenteredY(y));
     sprite.setTexture(this.getTilingImage(objectTemplate, x, y));
@@ -228,6 +233,10 @@ class Sprite2DRenderer extends RendererBase {
   };
 
   getTilingImage = (objectTemplate, x, y) => {
+    if (objectTemplate === undefined) {
+      console.log("Undefined object template");
+    };
+
     if (objectTemplate.tilingMode === "WALL_16") {
       const objectLeft = this.tileLocations.get(
         this.getObjectLocationKey(x - 1, y)

--- a/js/griddlyjs-app/src/renderer/level_player/scenes/HumanPlayerScene.js
+++ b/js/griddlyjs-app/src/renderer/level_player/scenes/HumanPlayerScene.js
@@ -454,11 +454,56 @@ class HumanPlayerScene extends Phaser.Scene {
 
     this.keyMap = new Map();
 
+    const mapKeyToAction = (key, actionName, actionTypeId, actionId, mapping) => {
+      const mappedKey = this.input.keyboard.addKey(key, false);
+      mappedKey.on("down", this.processUserKeydown);
+      mappedKey.on("up", this.processUserKeyup);
+
+      this.keyMap.set(key, {
+        actionName,
+        actionTypeId,
+        actionId,
+        description: mapping.description,
+      });
+    };
+
+    const presetActionKeys = {
+      "move": [ Phaser.Input.Keyboard.KeyCodes.E, Phaser.Input.Keyboard.KeyCodes.R ],
+      "rotate": [ Phaser.Input.Keyboard.KeyCodes.S, Phaser.Input.Keyboard.KeyCodes.A,
+                  Phaser.Input.Keyboard.KeyCodes.D, Phaser.Input.Keyboard.KeyCodes.W ],
+      "pickup": [ Phaser.Input.Keyboard.KeyCodes.Y ],
+      "use": [ Phaser.Input.Keyboard.KeyCodes.U ],
+      "shield": [ Phaser.Input.Keyboard.KeyCodes.O ],
+      "prestige": [ Phaser.Input.Keyboard.KeyCodes.PLUS ],
+      "attack": [ Phaser.Input.Keyboard.KeyCodes.NUMPAD_ONE,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_TWO,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_THREE,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_FOUR,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_FIVE,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_SIX,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_SEVEN,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_EIGHT,
+                  Phaser.Input.Keyboard.KeyCodes.NUMPAD_NINE,
+                ]
+    };
+
     actionNames.forEach((actionName, actionTypeId) => {
       const actionMapping = actionInputMappings[actionName];
       if (!actionMapping.internal) {
         const inputMappings = Object.entries(actionMapping.inputMappings);
         console.log(inputMappings);
+
+        // If the action is one of the preset actions, use the preset keys
+        if (actionName in presetActionKeys) {
+          const keys = presetActionKeys[actionName];
+          inputMappings.forEach((inputMapping) => {
+            const actionId = Number(inputMapping[0]);
+            const key = keys[actionId - 1];
+            const mapping = inputMapping[1];
+            mapKeyToAction(key, actionName, actionTypeId, actionId, mapping);
+          });
+          return;
+        }
 
         const actionDirections = new Set();
         inputMappings.forEach((inputMapping) => {
@@ -485,36 +530,16 @@ class HumanPlayerScene extends Phaser.Scene {
               key = movementKeys[this.toMovementKey(mapping.orientationVector)];
             }
 
-            const mappedKey = this.input.keyboard.addKey(key, false);
-            mappedKey.on("down", this.processUserKeydown);
-            mappedKey.on("up", this.processUserKeyup);
-
-            this.keyMap.set(key, {
-              actionName,
-              actionTypeId,
-              actionId,
-              description: mapping.description,
-            });
+            mapKeyToAction(key, actionName, actionTypeId, actionId, mapping);
           });
         } else {
           // We have an action Key
-
           inputMappings.forEach((inputMapping) => {
             const key = actionKeyOrder.pop();
 
             const actionId = Number(inputMapping[0]);
             const mapping = inputMapping[1];
-
-            const mappedKey = this.input.keyboard.addKey(key, false);
-            mappedKey.on("down", this.processUserKeydown);
-            mappedKey.on("up", this.processUserKeyup);
-
-            this.keyMap.set(key, {
-              actionName,
-              actionTypeId,
-              actionId,
-              description: mapping.description,
-            });
+            mapKeyToAction(key, actionName, actionTypeId, actionId, mapping);
           });
         }
       }

--- a/resources/games/RTS/Stratega/heal-or-die.yaml
+++ b/resources/games/RTS/Stratega/heal-or-die.yaml
@@ -2,8 +2,8 @@ Version: "0.1"
 Environment:
   Name: Heal Or Die
   Description: |
-    Game environment ported from https://github.com/GAIGResearch/Stratega. 
-    You have units that heal and units that perform close combat. 
+    Game environment ported from https://github.com/GAIGResearch/Stratega.
+    You have units that heal and units that perform close combat.
     Additionally, on every turn, the health of your units decreases. Win the game by killing your opponents pieces first.
   Observers:
     Sprite2D:

--- a/src/Griddly/Core/Grid.cpp
+++ b/src/Griddly/Core/Grid.cpp
@@ -497,6 +497,10 @@ void Grid::initObject(std::string objectName, std::vector<std::string> variableN
   objectCounters_.insert({objectName, {{0, std::make_shared<int32_t>(0)}}});
 
   for (auto& variableName : variableNames) {
+      objectVariables_.insert(variableName);
+  }
+  objectVariableMap_.clear();
+  for (auto& variableName : objectVariables_) {
     objectVariableIds_.insert({variableName, objectVariableIds_.size()});
   }
 

--- a/src/Griddly/Core/Grid.hpp
+++ b/src/Griddly/Core/Grid.hpp
@@ -110,7 +110,7 @@ class Grid : public std::enable_shared_from_this<Grid> {
   virtual const std::unordered_set<std::shared_ptr<Object>>& getObjects();
 
   virtual void addPlayerDefaultEmptyObject(std::shared_ptr<Object> emptyObject);
-  
+
   virtual void addPlayerDefaultBoundaryObject(std::shared_ptr<Object> boundaryObject);
 
   virtual std::shared_ptr<Object> getPlayerDefaultEmptyObject(uint32_t playerId) const;
@@ -199,6 +199,7 @@ class Grid : public std::enable_shared_from_this<Grid> {
   std::vector<std::unordered_set<glm::ivec2>> updatedLocations_;
 
   std::unordered_map<std::string, uint32_t> objectIds_;
+  std::set<std::string> objectVariables_;
   std::unordered_map<std::string, uint32_t> objectVariableIds_;
   std::unordered_map<std::string, std::vector<std::string>> objectVariableMap_;
   std::unordered_set<std::shared_ptr<Object>> objects_;


### PR DESCRIPTION
Provide a consistent ordering for objectVariables. Add them to a sorted set, and recompute objectVariableIds_ whenever new object types are added.

Fixes https://github.com/Bam4d/Griddly/issues/297

Tested manually and confirmed that get_object_variable_names() returns the variables in alphabetical order