### PR TITLE
Fix loading from state (triggered actions not being recreated, orientations)

### DIFF
--- a/src/Griddly/Core/GDY/Actions/Direction.hpp
+++ b/src/Griddly/Core/GDY/Actions/Direction.hpp
@@ -149,9 +149,9 @@ class DiscreteOrientation {
     const std::unordered_map<std::string, glm::ivec2> stringMapping = {
         {"NONE", {0, 0}},
         {"UP", {0, -1}},
-        {"RIGHT", {-1, 0}},
+        {"RIGHT", {1, 0}},
         {"DOWN", {0, 1}},
-        {"LEFT", {1, 0}},
+        {"LEFT", {-1, 0}},
     };
     const auto& vector = stringMapping.find(string);
     if (vector != stringMapping.end()) {

--- a/src/Griddly/Core/TurnBasedGameProcess.cpp
+++ b/src/Griddly/Core/TurnBasedGameProcess.cpp
@@ -124,6 +124,10 @@ std::shared_ptr<TurnBasedGameProcess> TurnBasedGameProcess::fromGameState(GameSt
 
   std::unordered_map<uint32_t, std::shared_ptr<Object>> loadedObjectMapping;
 
+  for (auto& actionTriggerDefinitionIt : objectGenerator->getActionTriggerDefinitions()) {
+    loadedGrid->addActionTrigger(actionTriggerDefinitionIt.first, actionTriggerDefinitionIt.second);
+  }
+
   // Behaviour probabilities
   loadedGrid->setBehaviourProbabilities(objectGenerator->getBehaviourProbabilities());
 


### PR DESCRIPTION
Triggered actions were not recreated when loading an environment's state with `env = env.load_state(state)` (as described in #299). This contribution should fix this bug.